### PR TITLE
Dynamic icons for TRV devices to show heating status

### DIFF
--- a/custom_components/wiser/climate.py
+++ b/custom_components/wiser/climate.py
@@ -95,7 +95,15 @@ class WiserRoom(ClimateDevice):
 
     @property
     def icon(self):
-        return "mdi:oil-temperature"
+        #Change icon to show if radiator is heating, not heating or set to off.
+        if self.handler.get_hub_data().getRoom(self.roomId).get('ControlOutputState') == 'On':
+            return 'mdi:radiator'
+        else:
+            if self.handler.get_hub_data().getRoom(self.roomId). \
+                   get('CurrentSetPoint') == -200:
+                return "mdi:radiator-off"
+            else:
+                return "mdi:radiator-disabled"
 
     @property
     def hvac_mode(self):


### PR DESCRIPTION
Hi,

Really love the work you have done on this Wiser integration to HA.  I wanted to be able to see visually if the radiator that the TRV is connected to was actually heating or not within an entity card.

As such, I have used the radiator icon variations to show heating, not heating and off.

If you like it and agree, I would love this to be part of the master branch.

Regards, Mark