### PR TITLE
Display presets and support boost

### DIFF
--- a/custom_components/wiser/__init__.py
+++ b/custom_components/wiser/__init__.py
@@ -39,7 +39,6 @@ PLATFORM_SCHEMA = vol.Schema({
     vol.Optional(CONF_BOOST_TEMP_TIME, default=30): vol.All(vol.Coerce(int))
 })
 
-
 def setup(hass, config):
     hub_host = config[DOMAIN][0][CONF_HOST]
     password = config[DOMAIN][0][CONF_PASSWORD]

--- a/custom_components/wiser/climate.py
+++ b/custom_components/wiser/climate.py
@@ -14,7 +14,7 @@ from homeassistant.components.climate import ClimateDevice
 #                                                    SUPPORT_TARGET_TEMPERATURE,
 #                                                    HVAC_MODE_HEAT_COOL)
 #
-from homeassistant.components.climate.const import (HVAC_MODE_AUTO, SUPPORT_TARGET_TEMPERATURE, SUPPORT_PRESET_MODE,HVAC_MODE_HEAT_COOL)
+from homeassistant.components.climate.const import (HVAC_MODE_AUTO, SUPPORT_TARGET_TEMPERATURE, SUPPORT_PRESET_MODE, HVAC_MODE_HEAT_COOL)
 from homeassistant.const import (ATTR_BATTERY_LEVEL, ATTR_TEMPERATURE,
                                  TEMP_CELSIUS)
 from homeassistant.helpers.entity import Entity
@@ -22,10 +22,12 @@ from homeassistant.helpers.entity import Entity
 _LOGGER = logging.getLogger(__name__)
 DOMAIN = 'wiser'
 
-PRESET_MANUAL = 'manual'
-PRESET_BOOST = 'boost'
+PRESET_MANUAL = 'Manual'
+PRESET_BOOST = 'Boost'
+PRESET_OVERRIDE = 'Override'
+PRESET_AUTO = 'Schedule'
 
-SUPPORT_FLAGS = SUPPORT_TARGET_TEMPERATURE
+SUPPORT_FLAGS = SUPPORT_TARGET_TEMPERATURE | SUPPORT_PRESET_MODE
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Setup the sensor platform."""
@@ -51,6 +53,7 @@ class WiserRoom(ClimateDevice):
         self.handler = handler
         self.roomId = room_id
         self._hvac_modes_list = [HVAC_MODE_AUTO, HVAC_MODE_HEAT_COOL]
+        self._preset_modes_list = [PRESET_AUTO, PRESET_BOOST]
 
     @property
     def supported_features(self):
@@ -103,7 +106,7 @@ class WiserRoom(ClimateDevice):
         if (state.lower() == "manual"):
             state = HVAC_MODE_HEAT_COOL
         if (state.lower()== "auto"):
-            state=HVAC_MODE_AUTO
+            state = HVAC_MODE_AUTO
         return state
 
     def set_hvac_mode(self, hvac_mode):
@@ -123,6 +126,39 @@ class WiserRoom(ClimateDevice):
         return self._hvac_modes_list
 
     @property
+    def preset_mode(self):
+        preset = self.handler.get_hub_data().getRoom(self.roomId).get('SetpointOrigin')
+        if (preset.lower() == "fromboost"):
+            preset = PRESET_BOOST
+        else:
+            if (preset.lower() == "frommanualoverride"):
+                preset = PRESET_OVERRIDE
+            else:
+                if (preset.lower() == "frommanualmode"):
+                    preset = PRESET_MANUAL
+                else:
+                    preset = PRESET_AUTO
+        return preset
+
+    def set_preset_mode(self, preset_mode):
+        """Set new preset mode."""
+        _LOGGER.debug("*******Setting Preset Mode {} for roomId {}".
+                      format(preset_mode, self.roomId))
+        #Convert HA preset to required api presets
+        if (preset_mode.lower() == 'schedule'):
+            preset_mode = 'auto'
+        if (preset_mode.lower() == 'override' or preset_mode.lower() == 'manual'):
+            preset_mode = 'manual'
+        self.handler.set_room_mode(self.roomId, preset_mode)
+
+        return True
+        
+    @property
+    def preset_modes(self):
+        """Return the list of available preset modes."""
+        return self._preset_modes_list
+      
+    @property
     def target_temperature(self):
         return self.handler.get_hub_data().getRoom(self.roomId). \
                    get('CurrentSetPoint') / 10
@@ -141,6 +177,10 @@ class WiserRoom(ClimateDevice):
         attrs = super().state_attributes
         attrs['percentage_demand'] = self.handler.get_hub_data(). \
             getRoom(self.roomId).get('PercentageDemand')
+        attrs['control_output_state'] = self.handler.get_hub_data(). \
+            getRoom(self.roomId).get('ControlOutputState')
+        attrs['set_point_origin'] = self.handler.get_hub_data(). \
+            getRoom(self.roomId).get('SetpointOrigin')
         attrs['heating_rate'] = self.handler.get_hub_data(). \
             getRoom(self.roomId).get('HeatingRate')
         attrs['window_state'] = self.handler.get_hub_data(). \

--- a/custom_components/wiser/climate.py
+++ b/custom_components/wiser/climate.py
@@ -14,7 +14,7 @@ from homeassistant.components.climate import ClimateDevice
 #                                                    SUPPORT_TARGET_TEMPERATURE,
 #                                                    HVAC_MODE_HEAT_COOL)
 #
-from homeassistant.components.climate.const import (HVAC_MODE_AUTO, SUPPORT_TARGET_TEMPERATURE, SUPPORT_PRESET_MODE, HVAC_MODE_HEAT_COOL)
+from homeassistant.components.climate.const import (HVAC_MODE_AUTO, SUPPORT_TARGET_TEMPERATURE, SUPPORT_PRESET_MODE, HVAC_MODE_HEAT, HVAC_MODE_OFF)
 from homeassistant.const import (ATTR_BATTERY_LEVEL, ATTR_TEMPERATURE,
                                  TEMP_CELSIUS)
 from homeassistant.helpers.entity import Entity
@@ -22,9 +22,13 @@ from homeassistant.helpers.entity import Entity
 _LOGGER = logging.getLogger(__name__)
 DOMAIN = 'wiser'
 
-PRESET_BOOST = 'Boost'
+PRESET_BOOST = 'boost'
+PRESET_BOOST30 = 'Boost 30m'
+PRESET_BOOST60 = 'Boost 1h'
+PRESET_BOOST120 = 'Boost 2h'
+PRESET_BOOST180 = 'Boost 3h'
+PRESET_BOOST_CANCEL = 'Cancel Boost'
 PRESET_OVERRIDE = 'Override'
-PRESET_AUTO = 'Schedule'
 PRESET_AWAY = 'Away Mode'
 PRESET_AWAY_BOOST = 'Away Boost'
 PRESET_AWAY_OVERRIDE = 'Away Override'
@@ -54,8 +58,8 @@ class WiserRoom(ClimateDevice):
         _LOGGER.info("Wiser Room Initialisation")
         self.handler = handler
         self.roomId = room_id
-        self._hvac_modes_list = [HVAC_MODE_AUTO, HVAC_MODE_HEAT_COOL]
-        self._preset_modes_list = [PRESET_AUTO, PRESET_BOOST]
+        self._hvac_modes_list = [HVAC_MODE_AUTO, HVAC_MODE_HEAT, HVAC_MODE_OFF]
+        self._preset_modes_list = [PRESET_BOOST30, PRESET_BOOST60, PRESET_BOOST120, PRESET_BOOST180, PRESET_BOOST_CANCEL]
 
     @property
     def supported_features(self):
@@ -69,10 +73,14 @@ class WiserRoom(ClimateDevice):
     @property
     def state(self):
         state=self.handler.get_hub_data().getRoom(self.roomId).get('Mode')
+        current_temp = self.handler.get_hub_data().getRoom(self.roomId).get('CurrentSetPoint')
         _LOGGER.info('State requested for room %s, state=%s', self.roomId,state)
-        # TODO :  State can be Manual, Auto or Boost.. Need to see how to deal with boost
+         
         if (state.lower() == "manual"):
-            state = HVAC_MODE_HEAT_COOL
+            if current_temp == -200:
+                state = HVAC_MODE_OFF
+            else:
+                state = HVAC_MODE_HEAT
         else:
             state = HVAC_MODE_AUTO
         return state
@@ -105,8 +113,12 @@ class WiserRoom(ClimateDevice):
     @property
     def hvac_mode(self):
         state = self.handler.get_hub_data().getRoom(self.roomId).get('Mode')
+        current_set_point = self.handler.get_hub_data().getRoom(self.roomId).get('CurrentSetPoint')
         if (state.lower() == "manual"):
-            state = HVAC_MODE_HEAT_COOL
+            if current_set_point == -200:
+                state = HVAC_MODE_OFF
+            else:
+                state = HVAC_MODE_HEAT
         if (state.lower()== "auto"):
             state = HVAC_MODE_AUTO
         return state
@@ -116,7 +128,7 @@ class WiserRoom(ClimateDevice):
         _LOGGER.debug("*******Setting Device Operation {} for roomId {}".
                       format(hvac_mode, self.roomId))
         # Convert HA heat_cool to manual as required by api
-        if (hvac_mode == "heat_cool"):
+        if (hvac_mode == HVAC_MODE_HEAT):
             hvac_mode = "manual"
         self.handler.set_room_mode(self.roomId, hvac_mode)
 
@@ -131,7 +143,7 @@ class WiserRoom(ClimateDevice):
     def preset_mode(self):
         wiser_preset = self.handler.get_hub_data().getRoom(self.roomId).get('SetpointOrigin')
         mode = self.handler.get_hub_data().getRoom(self.roomId).get('Mode')
-        preset = None
+       
         if (mode.lower() == HVAC_MODE_AUTO and wiser_preset.lower() == "frommanualoverride"):
                 preset = PRESET_OVERRIDE
         else:
@@ -143,16 +155,40 @@ class WiserRoom(ClimateDevice):
                 preset = PRESET_AWAY_OVERRIDE
             elif (wiser_preset.lower() == "fromboostduringaway"):
                 preset = PRESET_AWAY_BOOST
+            else:
+                preset = None
         return preset
 
     def set_preset_mode(self, preset_mode):
+        boost_time = self.handler.boost_time
+        boost_temp = self.handler.boost_temp
         """Set new preset mode."""
         _LOGGER.debug("*******Setting Preset Mode {} for roomId {}".
                       format(preset_mode, self.roomId))
         #Convert HA preset to required api presets
-        if (preset_mode.lower() == 'schedule'):
-            preset_mode = 'auto'
-        self.handler.set_room_mode(self.roomId, preset_mode)
+
+        """ Cancel boost mode """    
+        if (preset_mode.lower() == PRESET_BOOST_CANCEL.lower()):
+            preset_mode = self.handler.get_hub_data().getRoom(self.roomId).get('Mode')
+
+        """ Deal with boost time variations """
+        if (preset_mode.lower() == PRESET_BOOST30.lower()):
+            boost_time = 30
+        if (preset_mode.lower() == PRESET_BOOST60.lower()):
+            boost_time = 60
+        if (preset_mode.lower() == PRESET_BOOST120.lower()):
+            boost_time = 120
+        if (preset_mode.lower() == PRESET_BOOST180.lower()):
+            boost_time = 180
+
+        """ Set boost mode """
+        if (preset_mode[:5].lower() == PRESET_BOOST.lower()):
+            preset_mode = PRESET_BOOST
+            
+            """ Set boost temp to current + boost_temp """
+            boost_temp = (self.handler.get_hub_data().getRoom(self.roomId).get('CalculatedTemperature') / 10) + boost_temp
+        
+        self.handler.set_room_mode(self.roomId, preset_mode, boost_temp, boost_time)
 
         return True
         
@@ -163,8 +199,16 @@ class WiserRoom(ClimateDevice):
       
     @property
     def target_temperature(self):
-        return self.handler.get_hub_data().getRoom(self.roomId). \
+        target = self.handler.get_hub_data().getRoom(self.roomId). \
                    get('CurrentSetPoint') / 10
+                   
+        state=self.handler.get_hub_data().getRoom(self.roomId).get('Mode')
+        current_set_point = self.handler.get_hub_data().getRoom(self.roomId).get('CurrentSetPoint')
+        
+        if (state.lower() == 'manual' and current_set_point == -200):
+            target = None
+            
+        return target
 
     def update(self):
         _LOGGER.debug("*******************************************")
@@ -206,4 +250,4 @@ class WiserRoom(ClimateDevice):
         _LOGGER.debug("Value of wiserhub {}".format(self.handler))
 
         self.handler.set_room_temperature(self.roomId, target_temperature)
-
+        

--- a/custom_components/wiser/climate.py
+++ b/custom_components/wiser/climate.py
@@ -179,7 +179,7 @@ class WiserRoom(ClimateDevice):
             getRoom(self.roomId).get('PercentageDemand')
         attrs['control_output_state'] = self.handler.get_hub_data(). \
             getRoom(self.roomId).get('ControlOutputState')
-       attrs['heating_rate'] = self.handler.get_hub_data(). \
+        attrs['heating_rate'] = self.handler.get_hub_data(). \
             getRoom(self.roomId).get('HeatingRate')
         attrs['window_state'] = self.handler.get_hub_data(). \
             getRoom(self.roomId).get('WindowState')

--- a/custom_components/wiser/climate.py
+++ b/custom_components/wiser/climate.py
@@ -179,9 +179,7 @@ class WiserRoom(ClimateDevice):
             getRoom(self.roomId).get('PercentageDemand')
         attrs['control_output_state'] = self.handler.get_hub_data(). \
             getRoom(self.roomId).get('ControlOutputState')
-        attrs['set_point_origin'] = self.handler.get_hub_data(). \
-            getRoom(self.roomId).get('SetpointOrigin')
-        attrs['heating_rate'] = self.handler.get_hub_data(). \
+       attrs['heating_rate'] = self.handler.get_hub_data(). \
             getRoom(self.roomId).get('HeatingRate')
         attrs['window_state'] = self.handler.get_hub_data(). \
             getRoom(self.roomId).get('WindowState')


### PR DESCRIPTION
Added presets to show more than just auto or heat/cool.  Will now show if boosted, override on auto, away mode etc.

Also can either select boost from presets or use set preset service call.

Currently uses boost_temp and boost_time from configuration.yaml as didn't want to break this.  Improvements that could be made to this:
1) Would be to use a delta temp instead of fixed boost temp.
2) Ability to boost for different time periods.  Couldn't think of a way to do this other than a custom service as using different presets (Boost30, Boost60 etc) would not work (I think) if the boost was not set on HA.

Mark