### PR TITLE
Issue #48 - Get, set and copy schedules via HA service

### DIFF
--- a/Readme.Md
+++ b/Readme.Md
@@ -11,6 +11,8 @@ This repository contains a Home Assistant component + platforms, for the Drayton
     - Allows setting of temperatures from HA
     - Allows setting of boost temperature using Home Assistant Presets
     - Displays icon if radiator is heating (heat flowing) or not
+    - Service to set heating boost
+    - Services to get, set and copy heating schedules (**See instructions below**)
 
 - Switch platform
    - Allows the switching of Home/Away mode via a switch which means it can now be controlled by HA
@@ -105,6 +107,145 @@ I don't recommend you set the scan_interval too low, after all temperatures do n
 ```boost_temp``` is the delta temperature the radiator should be set to when boosted, default is 2
 
 ```boost_time``` is the time (in seconds) for which a boost should be active for, default is 30mins
+
+
+# Managing Schedules with HA
+
+New in version 1.x is the ability to get, set and copy schedules from climate devices.
+
+### Getting a Schedule
+Use the service wiser.get_schedule.
+This will require you to provide the entity ID of the wiser device and a file to copy this schedule to.
+It is recommended to create a directory in your config directory to store these.
+
+### Setting a Schedule
+Use the service wiser.set_schedule.
+This will require you to provide the entity ID of the wiser device and a file containing the schedule.
+
+A good place to start is to get a schedule from a device and see the file structure.  You can add times and temps within
+each day as you see fit.  As file created using the wiser.get_schedule service looks like below:
+```
+Name: Dining Room
+Description: Schedule for Dining Room
+Type: Heating
+Monday:
+  - Time: 07:30
+    Temp: 21
+  - Time: 08:30
+    Temp: 15
+  - Time: 16:30
+    Temp: 20
+  - Time: 22:30
+    Temp: 15
+Tuesday:
+  - Time: 07:30
+    Temp: 21
+  - Time: 08:30
+    Temp: 15
+  - Time: 16:30
+    Temp: 20
+  - Time: 22:30
+    Temp: 15
+Wednesday:
+  - Time: 07:30
+    Temp: 21
+  - Time: 08:30
+    Temp: 15
+  - Time: 16:30
+    Temp: 20
+  - Time: 22:30
+    Temp: 15
+Thursday:
+  - Time: 07:30
+    Temp: 21
+  - Time: 08:30
+    Temp: 15
+  - Time: 16:30
+    Temp: 20
+  - Time: 22:30
+    Temp: 15
+Friday:
+  - Time: 07:30
+    Temp: 21
+  - Time: 08:30
+    Temp: 15
+  - Time: 16:30
+    Temp: 20
+  - Time: 22:30
+    Temp: 15
+Saturday:
+  - Time: 07:00
+    Temp: 19
+  - Time: 10:00
+    Temp: 17
+  - Time: 16:00
+    Temp: 20
+  - Time: 23:00
+    Temp: 15
+Sunday:
+  - Time: 08:30
+    Temp: 21
+```
+If you are creating your own file (or editing one you have copied from a wiser device), you can use the 2 special day
+names of 'Weekdays' and 'Weekends' instead of listing individual days.  As below:
+```
+Name: Test Room
+Description: Schedule for Test Room
+Type: Heating
+Weekdays:
+  - Time: 07:30
+    Temp: 21.5
+  - Time: 08:30
+    Temp: 15
+  - Time: 16:30
+    Temp: 20
+  - Time: 22:30
+    Temp: 15
+Weekends:
+  - Time: 07:00
+    Temp: 19
+  - Time: 10:00
+    Temp: 17
+  - Time: 16:00
+    Temp: 20.5
+  - Time: 23:00
+    Temp: 15
+```
+You can also use a mixture of these special day names and normal days to override a specific day (providing the
+specific days names are below these special ones!).
+```
+Name: Test Room
+Description: Schedule for Test Room
+Type: Heating
+Weekdays:
+  - Time: 07:30
+    Temp: 21.5
+  - Time: 08:30
+    Temp: 15
+  - Time: 16:30
+    Temp: 20
+  - Time: 22:30
+    Temp: 15
+Weekends:
+  - Time: 07:00
+    Temp: 19
+  - Time: 10:00
+    Temp: 17
+  - Time: 16:00
+    Temp: 20.5
+  - Time: 23:00
+    Temp: 15
+Tuesday:
+  - Time: 08:00
+    Temp: 21.5
+  - Time: 20:00
+    Temp: 18.0
+```
+
+### Copying a Schedule
+Use the service wiser.copy_schedule.
+This will require you to provide an entity ID of the device to copy from and the entity ID of the device to copy to
+and will copy the schedule between them.
 
 ------
 

--- a/custom_components/wiser/__init__.py
+++ b/custom_components/wiser/__init__.py
@@ -273,7 +273,7 @@ class WiserHubHandle:
                                 for key, value in k.items(): 
                                     #Convert values and keys to human readable version
                                     if key == 'Time':
-                                        value =  (datetime.strptime(str(value),"%H%M")).strftime("%H:%M")
+                                        value =  (datetime.strptime(format(value,'04d'),"%H%M")).strftime("%H:%M")
                                     if key == 'DegreesC':
                                         key = 'Temp'
                                         if value < 0:

--- a/custom_components/wiser/__init__.py
+++ b/custom_components/wiser/__init__.py
@@ -173,3 +173,32 @@ class WiserHubHandle:
             self.wiserHubInstance.setHomeAwayMode(mode, away_temperature)
             self.force_next_scan()
             return True
+            
+    def get_room_schedule(self, room_id):
+        from wiserHeatingAPI import wiserHub
+        if self.wiserHubInstance is None:
+            self.wiserHubInstance = wiserHub.wiserHub(self.ip, self.secret)
+        with self.mutex:
+            scheduleData = self.wiserHubInstance.getRoomSchedule(room_id)
+            #Remove Id key from schedule
+            if "id" in scheduleData:
+                del scheduleData["id"]
+            return scheduleData
+            
+    def set_room_schedule(self, room_id, scheduleData):
+        from wiserHeatingAPI import wiserHub
+        if self.wiserHubInstance is None:
+            self.wiserHubInstance = wiserHub.wiserHub(self.ip, self.secret)
+        with self.mutex:
+            self.wiserHubInstance.setRoomSchedule(room_id, scheduleData)
+            self.force_next_scan()
+            return True
+            
+    def copy_room_schedule(self, room_id, to_room_id):
+        from wiserHeatingAPI import wiserHub
+        if self.wiserHubInstance is None:
+            self.wiserHubInstance = wiserHub.wiserHub(self.ip, self.secret)
+        with self.mutex:
+            self.wiserHubInstance.copyRoomSchedule(room_id, to_room_id)
+            self.force_next_scan
+            return True

--- a/custom_components/wiser/__init__.py
+++ b/custom_components/wiser/__init__.py
@@ -247,7 +247,9 @@ class WiserHubHandle:
         Param: scheduleData
         Param: mode
         """
-        WEEKDAYS = ['monday','tuesday','wednesday','thursday','friday','saturday','sunday']
+        WEEKDAYS = ['monday','tuesday','wednesday','thursday','friday']
+        WEEKENDS = ['saturday','sunday']
+        SPECIALDAYS = ['weekdays','weekends']
         #Remove Id key from schedule as not needed
         if "id" in scheduleData:
             del scheduleData["id"]
@@ -260,7 +262,7 @@ class WiserHubHandle:
         if mode.lower() == 'to':
             #Iterate through each day
             for day, sched in scheduleData.items():
-                if day.lower() in WEEKDAYS:
+                if day.lower() in (WEEKDAYS + WEEKENDS + SPECIALDAYS):
                     schedDay = {}
                     #Iterate through setpoint key for each day
                     for setpoint, times in sched.items():
@@ -288,7 +290,7 @@ class WiserHubHandle:
             #Convert to wiser format for setting schedules
             #Iterate through each day
             for day, times in scheduleData.items():
-                if day.lower() in WEEKDAYS:
+                if day.lower() in (WEEKDAYS + WEEKENDS + SPECIALDAYS):
                     schedDay = {}
                     schedSetpoints = []
                     #Iterate through each set of times for a day
@@ -308,6 +310,15 @@ class WiserHubHandle:
                             schedTime.update(tmp)
                         schedSetpoints.append(schedTime.copy())
                         schedDay = {"Setpoints" : schedSetpoints}
-                    scheduleOutput.update({ day : schedDay })
+                    #If using special days, convert to one entry for each day of week
+                    if day.lower() in SPECIALDAYS:
+                        if day.lower() == 'weekdays':
+                            for d in WEEKDAYS:
+                                scheduleOutput.update({ d.capitalize() : schedDay })
+                        if day.lower() == 'weekends':
+                            for d in WEEKENDS:
+                                scheduleOutput.update({ d.capitalize() : schedDay })
+                    else:
+                        scheduleOutput.update({ day : schedDay })
         _LOGGER.debug("Output from conversion: {}".format(scheduleOutput))
         return scheduleOutput

--- a/custom_components/wiser/climate.py
+++ b/custom_components/wiser/climate.py
@@ -135,7 +135,6 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     def get_schedule(service):
         """Handle the service call"""
         entity_id = service.data[ATTR_ENTITY_ID]
-        
         if entity_id:
             target_devices = [
                 device for device in wiser_rooms if device.entity_id in entity_id
@@ -143,21 +142,18 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
         else:
             _LOGGER.error("Cannot get schedule from this entity")
             return
-        
-        filename = service.data[ATTR_FILENAME]
-        
+        filename = service.data[ATTR_FILENAME] if service.data[ATTR_FILENAME] != "" else ("schedule_" + entity_id + ".yaml")
         #Get schedule data
         for target_device in target_devices:
             scheduleData = handler.get_room_schedule(target_device.roomId)
-        
         if scheduleData != None:
             #Write to file
             save_yaml(filename, scheduleData)
+            return
             
     def set_schedule(service):
         """Handle the service call"""
         entity_id = service.data[ATTR_ENTITY_ID]
-        
         if entity_id:
             target_devices = [
                 device for device in wiser_rooms if device.entity_id in entity_id
@@ -165,14 +161,13 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
         else:
             _LOGGER.error("Cannot set schedule of this entity")
             return
-        
         filename = service.data[ATTR_FILENAME]
-        
         #Get schedule data
         scheduleData = load_yaml(filename)
         #Set schedule
         for target_device in target_devices:
             handler.set_room_schedule(target_device.roomId, scheduleData)
+        return
             
     def copy_schedule(service):
         """Handle the service call"""
@@ -197,6 +192,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
         
         for target_device in target_devices:
             handler.copy_room_schedule(target_device.roomId, target_copyto_devices[0].roomId)
+        return
 
     hass.services.register(
         DOMAIN,
@@ -519,3 +515,4 @@ class WiserRoom(ClimateDevice):
         _LOGGER.debug("Value of wiserhub {}".format(self.handler))
 
         self.handler.set_room_temperature(self.roomId, target_temperature)
+

--- a/custom_components/wiser/services.yaml
+++ b/custom_components/wiser/services.yaml
@@ -5,11 +5,13 @@ boost_heating:
   fields:
     entity_id:
       {
-        description: Enter the entity_id for the device required to set the boost mode.,
-        example: "climate.heating",
+        description: Enter the entity_id for the room required to set the boost mode.,
+        example: "climate.wiser_lounge",
       }
     time_period:
-      { description: Set the time period for the boost in minutes., example: 60  }
+      { description: Set the time period for the boost in minutes., 
+        example: 60
+      }
     temperature:
       {
         description: Set the target temperature for the boost period.,
@@ -19,4 +21,41 @@ boost_heating:
       {
         description: Set the temperature increase for the boost period.,
         example: "2"
+      }
+get_schedule:
+  description: "Read the schedule from a roomId and write to an output file in yaml"
+  fields:
+    entity_id:
+      {
+        description: Enter the entity_id for the room to read the schedule.,
+        example: "climate.wiser_lounge",
+      }
+    filename:
+      { description: The filename to write out the yaml., 
+        example: schedule1.yaml  
+      }
+set_schedule:
+  description: "Read in the yaml schedule file and set the schedule in a room"
+  fields:
+    entity_id:
+      {
+        description: Enter the entity_id for the room to set the schedule.,
+        example: "climate.wiser_lounge",
+      }
+    filename:
+      { description: The filename to read the yaml schedule from., 
+        example: schedules/schedule1.yaml  
+      }
+copy_schedule:
+  description: "Copy the schedule in a room to another room"
+  fields:
+    entity_id:
+      {
+        description: Enter the entity_id for the room to copy the schedule from.,
+        example: "climate.wiser_lounge",
+      }
+    to_entity_id:
+      {
+        description: Enter the entity_id for the room to copy the schedule to.,
+        example: "climate.wiser_kitchen",
       }


### PR DESCRIPTION
Angelo,

This is certainly beta and may need some more testing and error handling but thought we could get all those that wanted to manage schedules to feedback on this.

This creates 3 services - wiser.get_schedule, wiser.set_schedule and wiser.copy_schedule.

Get_schedule - reads the room schedule and writes to the filename specified in yaml format.  This is however in wiser format ie times not in time format and temps in x10 format.  It is really so that you can download the current schedule and create the file to be able to amend or copy etc to other schedules.

Set_schedule - this reads the file specified and writes to the entity selected

Copy_schedule - the allows you to specify a from and to entity and it copies the schedule between them (this is something that the wiser app cannot do and is a real pain when setting up many rooms!)

In my mind, these services will allow someone to create multiple schedules for a room (one file for each) and be able to use automation to set the correct schedule as needed.

Let me know what you think.
KR
Mark

PS Obviously needs the updates to the API in my other PR.