### PR TITLE
Updated: Improved stability of wiser switch status after state change

### DIFF
--- a/custom_components/wiser/__init__.py
+++ b/custom_components/wiser/__init__.py
@@ -137,7 +137,7 @@ class WiserHubHandle:
         except BaseException as e:
             _LOGGER.debug("Error setting {} system switch! {}".format(switch, str(e)))
 
-    async def set_smart_plug_mode(self, plug_id, state):
+    async def set_smart_plug_state(self, plug_id, state):
         """
         Set the state of the smart plug,
         :param plug_id:
@@ -150,9 +150,9 @@ class WiserHubHandle:
             "Setting SmartPlug {} to {} ".format(plug_id, state))
 
         try:
-            self.wiserhub.setSmartPlugMode(plug_id,state.title() )
-            # Force a refresh to prevent the inconsistent state issue
-            self.wiserhub.refreshData()
+            self.wiserhub.setSmartPlugMode(plug_id,state)
+            # Add small delay to allow hub to update status before refreshing
+            await asyncio.sleep(0.5)
             await self.async_update(no_throttle=True)
 
         except BaseException as e:


### PR DESCRIPTION
Angelo,

Weirdly my plug is now working as expected.  Never understand this technology stuff!! ;-)

Anyway, am finding when using asyncs that it is better to hold values against the class instance so amended switch class to update status on update method and store then is_on returns this value.

Added a 0.5 sec delay before the forced update from hub.  Tested down to 0.1 without issue but 0.5 is both unnoticeable and ensures any slower hubs are also stable.  Seems to be working well.