### PR TITLE
Fixed: Device entity grouping issue

### DIFF
--- a/custom_components/wiser/sensor.py
+++ b/custom_components/wiser/sensor.py
@@ -237,9 +237,7 @@ class WiserDeviceSensor(WiserSensor):
             == "SmartPlug"
         ):
             # combine sensor for smartplug with smartplug device
-            identifier = "{}-{}".format(
-                self.data.wiserhub.getSmartPlug(self._deviceId)["Name"], self._deviceId
-            )
+            identifier = "{}-{}".format(self._device_name, self._deviceId)
 
             return {"identifiers": {(DOMAIN, identifier)}}
         else:


### PR DESCRIPTION
After changing smart plug name to be prefixed with Wiser, the switch and signal strength sensor were no longer grouping in the integration device list due to the identifier not using the prefixed name in the sensor.