### PR TITLE
Don't report room temperature if we don't know what it is

### DIFF
--- a/custom_components/wiser/climate.py
+++ b/custom_components/wiser/climate.py
@@ -309,15 +309,10 @@ class WiserRoom(ClimateEntity):
     @property
     def current_temperature(self):
         """Return current temp from data."""
-        temp = (
-            self.data.wiserhub.getRoom(self.room_id).get("CalculatedTemperature") / 10
-        )
-        if temp < self.min_temp:
-            # Sometimes we get really low temps (like -3000!),
-            # not sure why, if we do then just set it to -20 for now till i
-            # debug this.
-            temp = self.min_temp
-        return temp
+        raw = self.data.wiserhub.getRoom(self.room_id).get("CalculatedTemperature")
+        if raw == -32768: # Reported temperature if there are no thermostats available
+            return None
+        return raw / 10
 
     @property
     def icon(self):


### PR DESCRIPTION
The heat hub reports a value of -32768 for the temperature of a room if none of the thermostats in that room are currently available (eg. their batteries are flat or they are out of range). Reporting None means the graphs in history have gaps in them when the temperature isn't known (this seems sensible) but it does mean the standard climate cards look a little odd because no number is displayed...

Before change:
![image](https://user-images.githubusercontent.com/9699636/97083896-397ee180-160b-11eb-8f73-99c33bdb25a2.png)

After change:
![image](https://user-images.githubusercontent.com/9699636/95002327-776b8580-05ca-11eb-9d0d-35832e29273c.png)

Personally I prefer this (and see it as a bug with the climate card not displaying --- or whatever). Reporting the minimum value might break all sorts of automations. What do you guys think? I haven't seen any other 'special values'.

(PS. thanks for doing all this work, I started writing my own a while back but only implemented basic functionality which you have now far surpassed so I thought I might as well admit defeat and switch over :smile: )