### PR TITLE
Report None for the setpoint even if the system is not in manual

### DIFF
--- a/custom_components/wiser/climate.py
+++ b/custom_components/wiser/climate.py
@@ -452,7 +452,7 @@ class WiserRoom(ClimateEntity):
             "DisplayedSetPoint"
         )
 
-        if state.lower() == "manual" and current_set_point == -200:
+        if current_set_point == -200:
             target = None
 
         return target


### PR DESCRIPTION
Off is a valid setpoint in the schedule, currently this is reported as -20.0 and displayed as such on the standard lovelace card:

Before change:

![image](https://user-images.githubusercontent.com/9699636/97083803-94fc9f80-160a-11eb-8baf-9a51fb26529c.png)

This change removes the manual mode check so behaves similarly to when off is set manually.

After change:

![image](https://user-images.githubusercontent.com/9699636/97083956-82cf3100-160b-11eb-8bd4-5776942a8df8.png)

