### PR TITLE
Report None for the setpoint even if the system is not in manual

### DIFF
--- a/custom_components/wiser/climate.py
+++ b/custom_components/wiser/climate.py
@@ -445,17 +445,14 @@ class WiserRoom(ClimateEntity):
     @property
     def target_temperature(self):
         """Return target temp."""
-        target = self.data.wiserhub.getRoom(self.room_id).get("DisplayedSetPoint") / 10
-
-        state = self.data.wiserhub.getRoom(self.room_id).get("Mode")
         current_set_point = self.data.wiserhub.getRoom(self.room_id).get(
             "DisplayedSetPoint"
         )
 
         if current_set_point == -200:
-            target = None
+            return None
 
-        return target
+        return current_set_point / 10
 
     @property
     def state_attributes(self):

--- a/custom_components/wiser/climate.py
+++ b/custom_components/wiser/climate.py
@@ -452,7 +452,7 @@ class WiserRoom(ClimateEntity):
             "DisplayedSetPoint"
         )
 
-        if state.lower() == "manual" and current_set_point == -200:
+        if current_set_point == -200:
             target = None
 
         return target


### PR DESCRIPTION
Off is a valid setpoint in the schedule, currently this is reported as -20.0 and displayed as such on the standard lovelace card:

Before change:
![image](https://user-images.githubusercontent.com/9699636/97084209-67652580-160d-11eb-916e-4b88850fe465.png)

This change removes the manual mode check so behaves similarly to when off is set manually.

After change:
![image](https://user-images.githubusercontent.com/9699636/97084212-6c29d980-160d-11eb-978c-006c11af6cbd.png)

Sorry for the second pull request, I messed up the commit message before...
