### PR TITLE
Added default value to float

### DIFF
--- a/Recipes.md
+++ b/Recipes.md
@@ -91,7 +91,7 @@ sensor.yaml: history_stats spits out unitof measuerment in hours, so here is a s
     heating_time_flur:
       friendly_name: Heating Time Flur
       icon_template: mdi:radiator
-      value_template: "{{ states('sensor.heating_flur_on_today') | float * 60 }}"
+      value_template: "{{ states('sensor.heating_flur_on_today') | float(0) * 60 }}"
       unit_of_measurement: min
 ```
 


### PR DESCRIPTION
Added default to float, which will become necessary with Home Assistant 2022.1

See https://community.home-assistant.io/t/template-warning-float-unavailable-no-default/351486/2

It's a very minor change, but my first pull request ever in GitHub!

I redid this pull request as I hadn't made a branch first time around.