### PR TITLE
Add TEMP_OFF to target temperature

### DIFF
--- a/custom_components/wiser/climate.py
+++ b/custom_components/wiser/climate.py
@@ -28,7 +28,8 @@ from homeassistant.util import dt
 
 from wiserHeatAPIv2.wiserhub import (
     TEMP_MINIMUM,
-    TEMP_MAXIMUM
+    TEMP_MAXIMUM,
+    TEMP_OFF
 )
 
 from .const import (
@@ -327,7 +328,7 @@ class WiserRoom(ClimateEntity, WiserScheduleEntity):
     @property
     def target_temperature(self):
         """Return target temp."""
-        if self._room.mode == "Off":
+        if self._room.mode == "Off" or self._room.current_target_temperature == TEMP_OFF:
             return None
         return self._room.current_target_temperature
 


### PR DESCRIPTION
Prevents historical chart range issues and cleans up climate card

I have schedules that use the OFF value during some parts of the day.  This shows as -20 in the climate card and messes up the range on the stock climate history card.  This code returns None for the target temperature.  I've been running a similar patch in pre3.0 code for a couple of years, without any obvious issues.  

![Untitled](https://user-images.githubusercontent.com/11602094/166555093-79d9b50a-76a0-42ea-9ab1-d942ec789823.png)

Just upgraded to your latest beta, and have again added this patch.  

Please feel free to Close this PR, if you don't want to merge. 
