### PR TITLE
Mark LTS unavailable when giving 5oC reading

### DIFF
--- a/custom_components/wiser/sensor.py
+++ b/custom_components/wiser/sensor.py
@@ -705,6 +705,8 @@ class WiserLTSTempSensor(WiserSensor):
             self._state = self._data.wiserhub.rooms.get_by_id(
                 self._device_id
             ).current_temperature
+            if self._state == 5.0:
+                self._state = "Unavailable"
         elif self._lts_sensor_type == "floor_current_temp":
             self._state = self._data.wiserhub.devices.get_by_id(
                 self._device_id


### PR DESCRIPTION
When TRVs lose signal the temperature sensors report a temp of 5oC even though the temperature hasn't changed. This can't be distinguished from a true reading in other components and distorts average temperature calculations when calculated from the helper or template sensors. Applying this change to the LTS sensor only will rectify this while not affecting the main sensor. However, the same could be applied to the regular climate sensors if thought beneficial.