### PR TITLE
Ensure there is a directory to create before attempting to create it (when saving schedule to file)

### DIFF
--- a/custom_components/wiser/services.py
+++ b/custom_components/wiser/services.py
@@ -125,7 +125,7 @@ async def async_setup_services(hass: HomeAssistant, data):
                     filename = str(filename).replace("/config", "config")
                     # Check if dir exists, if not create it.
                     file_dir = os.path.dirname(filename)
-                    if not os.path.exists(file_dir):
+                    if file_dir and not os.path.exists(file_dir):
                         await aiofiles.os.makedirs(file_dir, exist_ok=True)
                     fn = getattr(entity, "get_schedule")
                     await fn(filename)


### PR DESCRIPTION
Fixes a minor issue introduced by https://github.com/asantaga/wiserHomeAssistantPlatform/commit/c9eebee4dd3c70409053fc146f22b728b4ab1a5d - [the docs](https://github.com/asantaga/wiserHomeAssistantPlatform/commit/c9eebee4dd3c70409053fc146f22b728b4ab1a5d) do say using a directory for storing schedules is recommended but it is not _required_ 🙂. Since 3.3.10 my automations started failing due to trying to create a directory with an empty string as its name as I've just kept them in the config directory.