### PR TITLE
Dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Wiser Home Assistant Integration v3.4.4
+# Wiser Home Assistant Integration v3.4.5
 
 [![hacs_badge](https://img.shields.io/badge/HACS-Default-orange.svg?style=for-the-badge)](https://github.com/hacs/integration)
 [![downloads](https://shields.io/github/downloads/asantaga/wiserHomeAssistantPlatform/latest/total?style=for-the-badge)](https://github.com/asantaga/wiserHomeAssistantPlatform)
@@ -23,6 +23,14 @@ For more information checkout the AMAZING community thread available on
 - Added PowerTagE support
 
 ## Change log
+
+- v3.4.5
+  - Bump api to v1.5.12 to improve performance of improve retry handling
+  - Fixed issue caused by v3.4.4 that heating actuators and power tags error on load (issue [#449](https://github.com/asantaga/wiserHomeAssistantPlatform/issues/449), #450)
+  - Fixed error setting up integration in config flow caused by session parameter being passed when no longer required
+  - Fixed issue on 3 channel hubs with Heating sensor names
+  - Fixed issue with signal sensor showing unknown on startup until first refresh
+  - Changed preset icon to HA standard
 
 - v3.4.4
   - Bump api to v1.5.11

--- a/README.md
+++ b/README.md
@@ -25,9 +25,9 @@ For more information checkout the AMAZING community thread available on
 ## Change log
 
 - v3.4.5
-  - Bump api to v1.5.12 to improve performance of improve retry handling
-  - Fixed issue caused by v3.4.4 that heating actuators and power tags error on load (issue [#449](https://github.com/asantaga/wiserHomeAssistantPlatform/issues/449), #450)
-  - Fixed error setting up integration in config flow caused by session parameter being passed when no longer required
+  - Bump api to v1.5.12 to improve performance of improved retry handling
+  - Fixed issue caused by v3.4.4 that heating actuators and power tags error on load (issue [#449](https://github.com/asantaga/wiserHomeAssistantPlatform/issues/449), [#450](https://github.com/asantaga/wiserHomeAssistantPlatform/issues/450))
+  - Fixed error setting up integration in config flow caused by session parameter being passed when no longer required (issue [#446](https://github.com/asantaga/wiserHomeAssistantPlatform/issues/446))
   - Fixed issue on 3 channel hubs with Heating sensor names
   - Fixed issue with signal sensor showing unknown on startup until first refresh
   - Changed preset icon to HA standard

--- a/custom_components/wiser/config_flow.py
+++ b/custom_components/wiser/config_flow.py
@@ -69,7 +69,6 @@ async def validate_input(hass: HomeAssistant, data):
         host=data[CONF_HOST],
         port=data[CONF_PORT],
         secret=data[CONF_PASSWORD],
-        session=async_get_clientsession(hass),
         extra_config_file=hass.config.config_dir + CUSTOM_DATA_STORE,
         enable_automations=False,
     )

--- a/custom_components/wiser/const.py
+++ b/custom_components/wiser/const.py
@@ -5,7 +5,7 @@ https://github.com/asantaga/wiserHomeAssistantPlatform
 Angelosantagata@gmail.com
 
 """
-VERSION = "3.4.4"
+VERSION = "3.4.5"
 DOMAIN = "wiser"
 DATA_WISER_CONFIG = "wiser_config"
 URL_BASE = "/wiser"

--- a/custom_components/wiser/icons.json
+++ b/custom_components/wiser/icons.json
@@ -4,7 +4,7 @@
             "wiser": {
                 "state_attributes": {
                     "preset_mode": {
-                        "default": "mdi:home-thermometer",
+                        "default": "mdi:tune-variant",
                         "state": {
                             "Advance Schedule": "mdi:calendar-arrow-right",
                             "Cancel Overrides": "mdi:close-circle",

--- a/custom_components/wiser/manifest.json
+++ b/custom_components/wiser/manifest.json
@@ -16,7 +16,7 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/asantaga/wiserHomeAssistantPlatform/issues",
   "requirements": [
-    "aioWiserHeatAPI==1.5.11"
+    "aioWiserHeatAPI==1.5.12"
   ],
   "version": "3.4.3",
   "zeroconf": [

--- a/custom_components/wiser/manifest.json
+++ b/custom_components/wiser/manifest.json
@@ -18,7 +18,7 @@
   "requirements": [
     "aioWiserHeatAPI==1.5.12"
   ],
-  "version": "3.4.3",
+  "version": "3.4.5",
   "zeroconf": [
     {
       "type": "_http._tcp.local.",

--- a/custom_components/wiser/sensor.py
+++ b/custom_components/wiser/sensor.py
@@ -1193,25 +1193,36 @@ class WiserLTSPowerSensor(WiserSensor):
         """Fetch new state data for the sensor."""
         super()._handle_coordinator_update()
         if self._lts_sensor_type == "Power":
-            self._state = self._data.wiserhub.devices.get_by_id(self._device_id).get(
-                "instantaneous_power", 0
-            )
+            if self._data.wiserhub.devices.get_by_id(
+                self._device_id
+            ).instantaneous_power:
+                self._state = self._data.wiserhub.devices.get_by_id(
+                    self._device_id
+                ).instantaneous_power
+            else:
+                self._state = 0
         elif self._lts_sensor_type == "Energy":
-            self._state = round(
-                self._data.wiserhub.devices.get_by_id(self._device_id).get(
-                    "delivered_power", 0
+            if self._data.wiserhub.devices.get_by_id(self._device_id).delivered_power:
+                self._state = round(
+                    self._data.wiserhub.devices.get_by_id(
+                        self._device_id
+                    ).delivered_power
+                    / 1000,
+                    2,
                 )
-                / 1000,
-                2,
-            )
+            else:
+                self._state = 0
         elif self._lts_sensor_type == "EnergyReceived":
-            self._state = round(
-                self._data.wiserhub.devices.get_by_id(self._device_id).get(
-                    "received_power", 0
+            if self._data.wiserhub.devices.get_by_id(self._device_id).received_power:
+                self._state = round(
+                    self._data.wiserhub.devices.get_by_id(
+                        self._device_id
+                    ).received_power
+                    / 1000,
+                    2,
                 )
-                / 1000,
-                2,
-            )
+            else:
+                self._state = 0
         self.async_write_ha_state()
 
     @property

--- a/custom_components/wiser/sensor.py
+++ b/custom_components/wiser/sensor.py
@@ -541,6 +541,18 @@ class WiserSystemCircuitState(WiserSensor):
         self.async_write_ha_state()
 
     @property
+    def name(self):
+        """Return name of sensor."""
+        if (
+            self._sensor_type == "Heating"
+            and len(self._data.wiserhub.heating_channels.all) > 1
+        ):
+            return get_device_name(
+                self._data, 0, self._sensor_type + " Channel " + str(self._device_id)
+            )
+        return get_device_name(self._data, 0, self._sensor_type)
+
+    @property
     def icon(self):
         """Return icon."""
         if self._sensor_type == "Heating":

--- a/custom_components/wiser/sensor.py
+++ b/custom_components/wiser/sensor.py
@@ -332,6 +332,7 @@ class WiserDeviceSignalSensor(WiserSensor):
             self._device = self._data.wiserhub.system
         else:
             self._device = self._data.wiserhub.devices.get_by_id(self._device_id)
+        self._state = self._device.signal.displayed_signal_strength
 
     @callback
     def _handle_coordinator_update(self) -> None:


### PR DESCRIPTION
- Bump api to v1.5.12 to improve performance of improved retry handling
- Fixed issue caused by v3.4.4 that heating actuators and power tags error on load (issue [#449](https://github.com/asantaga/wiserHomeAssistantPlatform/issues/449), [#450](https://github.com/asantaga/wiserHomeAssistantPlatform/issues/450))
- Fixed error setting up integration in config flow caused by session parameter being passed when no longer required (issue [#446](https://github.com/asantaga/wiserHomeAssistantPlatform/issues/446))
- Fixed issue on 3 channel hubs with Heating sensor names
- Fixed issue with signal sensor showing unknown on startup until first refresh
- Changed preset icon to HA standard