### PR TITLE
v3.4.15

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ For more information checkout the AMAZING community thread available on
 ## What's New in 3.4?
 
 - Added support for v2 hub
-- Added PowerTagE support
+- Added support for many new v2 hub devices
 - Climate entity for controlling hot water with external tank temp sensor
 
 ## Installing

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Wiser Home Assistant Integration v3.4.14
+# Wiser Home Assistant Integration v3.4.15
 
 [![hacs_badge](https://img.shields.io/badge/HACS-Default-orange.svg?style=for-the-badge)](https://github.com/hacs/integration)
 [![downloads](https://shields.io/github/downloads/asantaga/wiserHomeAssistantPlatform/latest/total?style=for-the-badge)](https://github.com/asantaga/wiserHomeAssistantPlatform)
@@ -28,6 +28,13 @@ For more information checkout the AMAZING community thread available on
 [![Open your Home Assistant instance and open a repository inside the Home Assistant Community Store.](https://my.home-assistant.io/badges/hacs_repository.svg)](https://my.home-assistant.io/redirect/hacs_repository/?owner=asantaga&repository=wiserHomeAssistantPlatform&category=integration)
 
 ## Change log
+
+- v3.4.15
+  - Added experimental hw climate mode to operate differently.  See wiki for details
+  - Changed min/max hw climate temp range from 40-80C to 10-80C - issue [#545](https://github.com/asantaga/wiserHomeAssistantPlatform/issues/545)
+  - Fixed issue whereby hw climate errors if temp sensor not available after HA start - issue [#541](https://github.com/asantaga/wiserHomeAssistantPlatform/issues/541)
+  - Fixed issue whereby hw climate config requires some entry in the temp sensor select option, even if not enabled - issue [#544](https://github.com/asantaga/wiserHomeAssistantPlatform/issues/544)
+  - Fixed issue whereby hw min does not change when setting both via service call if temps are 1C or less different - issue [#547](https://github.com/asantaga/wiserHomeAssistantPlatform/issues/547)
 
 - v3.4.14
   - Fixed issue causing integration not to load in some circumstances due to failed config entry migration - issue #539

--- a/custom_components/wiser/climate.py
+++ b/custom_components/wiser/climate.py
@@ -733,7 +733,6 @@ class WiserHotWater(CoordinatorEntity, ClimateEntity, WiserScheduleEntity):
         self._hvac_modes_list = list(HVAC_MODE_HASS_TO_WISER.keys())
         self._schedule = self.hotwater.schedule
         self._boosted_time = 0
-        self._boost_mode = ""
         self._keep_cycling: bool = True
         self._boost_keep_cycling: bool = True
 
@@ -916,10 +915,6 @@ class WiserHotWater(CoordinatorEntity, ClimateEntity, WiserScheduleEntity):
     @property
     def preset_mode(self):
         """Get current preset mode."""
-        if self.data.hw_climate_experimental_mode:
-            if self.hotwater.is_boosted and self._boost_mode:
-                return self._boost_mode
-
         try:
             if self.hotwater.is_boosted:
                 if int(self.hotwater.boost_time_remaining / 60) != 0:
@@ -948,7 +943,6 @@ class WiserHotWater(CoordinatorEntity, ClimateEntity, WiserScheduleEntity):
                     await self.hotwater.schedule_advance()
                 elif preset_mode.lower().startswith(TEXT_BOOST.lower()):
                     # Lookup boost duration
-                    self._boost_mode = preset_mode
                     self._keep_cycling = True
 
                     duration = WISER_BOOST_DURATION[preset_mode]

--- a/custom_components/wiser/climate.py
+++ b/custom_components/wiser/climate.py
@@ -722,6 +722,7 @@ class WiserHotWater(CoordinatorEntity, ClimateEntity, WiserScheduleEntity):
     """WiserHotWater ClientEntity Object."""
 
     _enable_turn_on_off_backwards_compatibility = False
+    _attr_translation_key = "wiser"
 
     def __init__(self, hass: HomeAssistant, coordinator) -> None:
         """Initialize the sensor."""

--- a/custom_components/wiser/climate.py
+++ b/custom_components/wiser/climate.py
@@ -787,7 +787,9 @@ class WiserHotWater(CoordinatorEntity, ClimateEntity, WiserScheduleEntity):
         _LOGGER.debug("%s updating", self.name)
 
         previous_hotwater_values = self._hotwater
+        previous_hotwater_values._current_temperature = self.current_temperature
         self._hotwater = self._data.wiserhub.hotwater
+        self._hotwater._current_temperature = self.current_temperature
         self._schedule = self.hotwater.schedule
 
         if not self.hotwater.is_boosted:

--- a/custom_components/wiser/climate.py
+++ b/custom_components/wiser/climate.py
@@ -1042,6 +1042,12 @@ class WiserHotWater(CoordinatorEntity, ClimateEntity, WiserScheduleEntity):
             # into manual mode.
             return False
 
+        if not self.current_temperature:
+            # No current temp sensor providing value yet
+            # return
+            _LOGGER.debug("No value from current temperature sensor")
+            return False
+
         # Reasons it should heat
         if self.current_temperature <= self.target_temperature_low or (
             self.current_temperature <= self.target_temperature_high

--- a/custom_components/wiser/climate.py
+++ b/custom_components/wiser/climate.py
@@ -746,7 +746,11 @@ class WiserHotWater(CoordinatorEntity, ClimateEntity, WiserScheduleEntity):
         self._boost_keep_cycling: bool = True
         # Prevent hot water turning on if in heat mode at restart
         # requires manual turn on to start if not already on
-        if self.hvac_mode == HVACMode.HEAT and not self._hotwater.manual_heat:
+        if (
+            self.hvac_mode == HVACMode.HEAT
+            and not self._hotwater.manual_heat
+            and not self._data.hw_climate_experimental_mode
+        ):
             self._keep_cycling = False
 
         _LOGGER.debug("%s %s initiliase", self._data.wiserhub.system.name, self.name)

--- a/custom_components/wiser/climate.py
+++ b/custom_components/wiser/climate.py
@@ -865,13 +865,13 @@ class WiserHotWater(CoordinatorEntity, ClimateEntity, WiserScheduleEntity):
 
     async def async_set_temperature(self, **kwargs):
         """Set new target temperatures."""
+        if high_temp := kwargs.get("target_temp_high"):
+            await self.hotwater.set_target_temperature_high(high_temp)
         if low_temp := kwargs.get("target_temp_low"):
             # Low must be a minimum of 1C below high to prevent oscillating on/off
             if self.target_temperature_high - low_temp < 1:
                 low_temp = self.target_temperature_high - 1
             await self.hotwater.set_target_temperature_low(low_temp)
-        if high_temp := kwargs.get("target_temp_high"):
-            await self.hotwater.set_target_temperature_high(high_temp)
         _LOGGER.debug(
             "Setting temperature range for %s to between %s and %s",
             self.name,

--- a/custom_components/wiser/config_flow.py
+++ b/custom_components/wiser/config_flow.py
@@ -39,6 +39,7 @@ from .const import (
     CONF_AUTOMATIONS_HW_AUTO_MODE,
     CONF_AUTOMATIONS_HW_BOOST_MODE,
     CONF_AUTOMATIONS_HW_CLIMATE,
+    CONF_AUTOMATIONS_HW_CLIMATE_EXPERIMENTAL,
     CONF_AUTOMATIONS_HW_HEAT_MODE,
     CONF_AUTOMATIONS_HW_SENSOR_ENTITY_ID,
     CONF_AUTOMATIONS_PASSIVE,
@@ -371,6 +372,12 @@ class WiserOptionsFlowHandler(config_entries.OptionsFlow):
                             CONF_AUTOMATIONS_HW_CLIMATE,
                             default=options.get(CONF_AUTOMATIONS_HW_CLIMATE, {}).get(
                                 CONF_AUTOMATIONS_HW_CLIMATE, False
+                            ),
+                        ): bool,
+                        vol.Optional(
+                            CONF_AUTOMATIONS_HW_CLIMATE_EXPERIMENTAL,
+                            default=options.get(CONF_AUTOMATIONS_HW_CLIMATE, {}).get(
+                                CONF_AUTOMATIONS_HW_CLIMATE_EXPERIMENTAL, False
                             ),
                         ): bool,
                         vol.Optional(

--- a/custom_components/wiser/config_flow.py
+++ b/custom_components/wiser/config_flow.py
@@ -376,7 +376,7 @@ class WiserOptionsFlowHandler(config_entries.OptionsFlow):
                         vol.Optional(
                             CONF_AUTOMATIONS_HW_SENSOR_ENTITY_ID,
                             default=options.get(CONF_AUTOMATIONS_HW_CLIMATE, {}).get(
-                                CONF_AUTOMATIONS_HW_SENSOR_ENTITY_ID
+                                CONF_AUTOMATIONS_HW_SENSOR_ENTITY_ID, "sensor.no_sensor"
                             ),
                         ): EntitySelector(
                             EntitySelectorConfig(

--- a/custom_components/wiser/const.py
+++ b/custom_components/wiser/const.py
@@ -1,5 +1,4 @@
-"""
-Constants  for Wiser Platform.
+"""Constants  for Wiser Platform.
 
 https://github.com/asantaga/wiserHomeAssistantPlatform
 Angelosantagata@gmail.com
@@ -7,7 +6,6 @@ Angelosantagata@gmail.com
 """
 
 from enum import StrEnum
-
 
 VERSION = "3.4.14"
 DOMAIN = "wiser"
@@ -72,7 +70,7 @@ DEFAULT_PASSIVE_TEMP_INCREMENT = 0.5
 DEFAULT_HW_AUTO_MODE = HWCycleModes.CONTINUOUS
 DEFAULT_HW_HEAT_MODE = HWCycleModes.CONTINUOUS
 DEFAULT_HW_BOOST_MODE = HWCycleModes.CONTINUOUS
-HW_CLIMATE_MIN_TEMP = 40
+HW_CLIMATE_MIN_TEMP = 10
 HW_CLIMATE_MAX_TEMP = 80
 
 # Setpoint Modes
@@ -89,6 +87,7 @@ CONF_SETPOINT_MODE = "setpoint_mode"
 CONF_HOSTNAME = "hostname"
 CONF_RESTORE_MANUAL_TEMP_OPTION = "restore_manual_temp_option"
 CONF_AUTOMATIONS_HW_CLIMATE = "automations_hw_climate"
+CONF_AUTOMATIONS_HW_CLIMATE_EXPERIMENTAL = "experimental_mode"
 CONF_AUTOMATIONS_HW_AUTO_MODE = "hotwater_auto_mode"
 CONF_AUTOMATIONS_HW_CLIMATE = "hotwater_climate"
 CONF_AUTOMATIONS_HW_HEAT_MODE = "hotwater_heat_mode"

--- a/custom_components/wiser/const.py
+++ b/custom_components/wiser/const.py
@@ -7,7 +7,7 @@ Angelosantagata@gmail.com
 
 from enum import StrEnum
 
-VERSION = "3.4.14"
+VERSION = "3.4.15"
 DOMAIN = "wiser"
 DATA_WISER_CONFIG = "wiser_config"
 URL_BASE = "/wiser"

--- a/custom_components/wiser/coordinator.py
+++ b/custom_components/wiser/coordinator.py
@@ -34,6 +34,7 @@ from .const import (
     CONF_AUTOMATIONS_HW_SENSOR_ENTITY_ID,
     CONF_AUTOMATIONS_PASSIVE,
     CONF_AUTOMATIONS_PASSIVE_TEMP_INCREMENT,
+    CONF_AUTOMATIONS_HW_CLIMATE_EXPERIMENTAL,
     CONF_HEATING_BOOST_TEMP,
     CONF_HEATING_BOOST_TIME,
     CONF_HW_BOOST_TIME,
@@ -153,6 +154,9 @@ class WiserUpdateCoordinator(DataUpdateCoordinator):
         self.hw_boost_mode = config_entry.options.get(
             CONF_AUTOMATIONS_HW_CLIMATE, {}
         ).get(CONF_AUTOMATIONS_HW_BOOST_MODE, DEFAULT_HW_BOOST_MODE)
+        self.hw_climate_experimental_mode = config_entry.options.get(
+            CONF_AUTOMATIONS_HW_CLIMATE, {}
+        ).get(CONF_AUTOMATIONS_HW_CLIMATE_EXPERIMENTAL, False)
 
         self.wiserhub = WiserAPI(
             host=config_entry.data[CONF_HOST],

--- a/custom_components/wiser/events.py
+++ b/custom_components/wiser/events.py
@@ -58,6 +58,8 @@ WISER_COMMON_EVENT_DATA = {
     DOMAIN_CLIMATE: [
         "current_temperature",
         "current_target_temperature",
+        "current_target_temperature_high",
+        "current_target_temperature_low",
         "is_boosted",
         "is_heating",
         "boost_time_remaining",
@@ -105,9 +107,15 @@ def fire_events(hass: HomeAssistant, entity_id: str, old_state: dict, new_state:
 
                 if event_data:
                     for attr in event_data:
-                        if hasattr(old_state, attr):
+                        if (
+                            hasattr(old_state, attr)
+                            and getattr(old_state, attr) is not None
+                        ):
                             old_state_attr[attr] = getattr(old_state, attr)
-                        if hasattr(new_state, attr):
+                        if (
+                            hasattr(new_state, attr)
+                            and getattr(old_state, attr) is not None
+                        ):
                             new_state_attr[attr] = getattr(new_state, attr)
 
                     if old_state_attr:

--- a/custom_components/wiser/manifest.json
+++ b/custom_components/wiser/manifest.json
@@ -16,7 +16,7 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/asantaga/wiserHomeAssistantPlatform/issues",
   "requirements": [
-    "aioWiserHeatAPI==1.6.4"
+    "aioWiserHeatAPI==1.6.5"
   ],
   "version": "3.4.15",
   "zeroconf": [

--- a/custom_components/wiser/manifest.json
+++ b/custom_components/wiser/manifest.json
@@ -18,7 +18,7 @@
   "requirements": [
     "aioWiserHeatAPI==1.6.4"
   ],
-  "version": "3.4.14",
+  "version": "3.4.15",
   "zeroconf": [
     {
       "type": "_http._tcp.local.",

--- a/custom_components/wiser/select.py
+++ b/custom_components/wiser/select.py
@@ -22,7 +22,7 @@ async def async_setup_entry(hass: HomeAssistant, config_entry, async_add_entitie
     data = hass.data[DOMAIN][config_entry.entry_id][DATA]
     wiser_selects = []
 
-    if data.wiserhub.hotwater:
+    if data.wiserhub.hotwater and not data.enable_hw_climate:
         _LOGGER.debug("Setting up Hot Water mode select")
         wiser_selects.extend([WiserHotWaterModeSelect(data)])
 

--- a/custom_components/wiser/switch.py
+++ b/custom_components/wiser/switch.py
@@ -225,7 +225,7 @@ async def async_setup_entry(hass: HomeAssistant, config_entry, async_add_entitie
                 )
 
     # Add hw climate switches
-    if data.enable_hw_climate:
+    if data.enable_hw_climate and not data.hw_climate_experimental_mode:
         wiser_switches.append(WiserHWClimateManualHeatSwitch(data, 0, "Manual Heat"))
 
     async_add_entities(wiser_switches)

--- a/custom_components/wiser/translations/de.json
+++ b/custom_components/wiser/translations/de.json
@@ -59,10 +59,10 @@
         "description": "Warmwasser-Klimaparameter",
         "data": {
           "hotwater_climate": "Aktivieren Sie die Climate-Entität",
+          "experimental_mode": "Aktivieren Sie den experimentellen Arbeitsmodus",
           "hotwater_auto_mode": "Warmwasser-Automatikmodus",
           "hotwater_heat_mode": "Warmwasser-Heizmodus",
-          "hotwater_sensor_entity_id": "Warmwasser-Temperatursensor",
-          "hotwater_target_temperature": "Standard-Warmwasser-Zieltemperatur"
+          "hotwater_sensor_entity_id": "Warmwasser-Temperatursensor"
         }
       },
       "automation_params": {

--- a/custom_components/wiser/translations/en.json
+++ b/custom_components/wiser/translations/en.json
@@ -74,11 +74,11 @@
             "description": "Enable Hot Water climate control.  See wiki for how it works",
             "data": {
               "hotwater_climate": "Enable The Climate Entity",
+              "experimental_mode": "Enable experimental working mode",
               "hotwater_auto_mode": "Hot Water Auto Mode",
               "hotwater_heat_mode": "Hot Water Heat Mode",
               "hotwater_boost_mode": "Hot Water Boost Mode",
-              "hotwater_sensor_entity_id": "Hot Water Temperature Sensor",
-              "hotwater_target_temperature": "Default Hot Water Target Temperature (°C)"
+              "hotwater_sensor_entity_id": "Hot Water Temperature Sensor"
             }
           }
         }

--- a/custom_components/wiser/translations/fr.json
+++ b/custom_components/wiser/translations/fr.json
@@ -59,11 +59,11 @@
         "description": "Paramètres climatiques de l'eau chaude",
         "data": {
           "hotwater_climate": "Activer l'entité climatique",
+          "experimental_mode": "Activer le mode de travail expérimental",
           "hotwater_auto_mode": "Mode automatique d'eau chaude",
           "hotwater_heat_mode": "Mode de chauffage de l'eau chaude",
           "hotwater_sensor_entity_id": "Capteur de température d'eau chaude",
-          "hotwater_schedule_mode": "Mode de programmation d'eau chaude",
-          "hotwater_target_temperature": "Défaulttempérature cible de l'eau chaud"
+          "hotwater_schedule_mode": "Mode de programmation d'eau chaude"
         }
       },
       "automation_params": {


### PR DESCRIPTION
- Added experimental hw climate mode to operate differently.  See wiki for details
- Changed min/max hw climate temp range from 40-80C to 10-80C - issue [#545](https://github.com/asantaga/wiserHomeAssistantPlatform/issues/545)
- Fixed issue whereby hw climate errors if temp sensor not available after HA start - issue [#541](https://github.com/asantaga/wiserHomeAssistantPlatform/issues/541)
- Fixed issue whereby hw climate config requires some entry in the temp sensor select option, even if not enabled - issue [#544](https://github.com/asantaga/wiserHomeAssistantPlatform/issues/544)
- Fixed issue whereby hw min does not change when setting both via service call if temps are 1C or less different - issue [#547](https://github.com/asantaga/wiserHomeAssistantPlatform/issues/547)
