### PR TITLE
feat: add Hot Water on/off switch entity

### DIFF
--- a/custom_components/wiser/switch.py
+++ b/custom_components/wiser/switch.py
@@ -223,6 +223,10 @@ async def async_setup_entry(hass: HomeAssistant, config_entry, async_add_entitie
     if data.enable_hw_climate and not data.hw_climate_experimental_mode:
         wiser_switches.append(WiserHWClimateManualHeatSwitch(data, 0, "Manual Heat"))
 
+    # Add hot water on/off switch (non hw-climate mode only)
+    if data.wiserhub.hotwater and not data.enable_hw_climate:
+        wiser_switches.append(WiserHotWaterSwitch(data, 0, "Hot Water"))
+
     async_add_entities(wiser_switches)
 
     return True
@@ -1023,5 +1027,63 @@ class WiserHWClimateManualHeatSwitch(WiserSwitch):
     async def async_turn_off(self, **kwargs):
         """Turn off hw climate manual heat."""
         await self._data.wiserhub.hotwater.set_manual_heat(False)
+        await self.async_force_update()
+
+
+class WiserHotWaterSwitch(WiserSwitch):
+    """Class for Hot Water on/off switch, reflecting the true on/off state."""
+
+    def __init__(
+        self,
+        data,
+        device_id,
+        name,
+    ) -> None:
+        """Initialize the sensor."""
+        self._name = name
+        self._device_id = device_id
+        self._hotwater = data.wiserhub.hotwater
+        super().__init__(data, name, "", "hotwater", "mdi:water-boiler")
+
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        """Async Update to HA."""
+        super()._handle_coordinator_update()
+        self._hotwater = self._data.wiserhub.hotwater
+        self.async_write_ha_state()
+
+    @property
+    def is_on(self) -> bool:
+        """Return the state of the entity."""
+        return self._hotwater.current_state == "On"
+
+    @property
+    def name(self):
+        """Return Name of device."""
+        return get_device_name(self._data, self._hotwater.id, "Hot Water")
+
+    @property
+    def device_info(self):
+        """Return device specific attributes."""
+        return {
+            "name": get_device_name(self._data, self._hotwater.id, "Hot Water"),
+            "identifiers": {
+                (DOMAIN, get_identifier(self._data, self._hotwater.id, "hot_water"))
+            },
+            "manufacturer": MANUFACTURER,
+            "model": HOT_WATER.title(),
+            "via_device": (DOMAIN, self._data.wiserhub.system.name),
+        }
+
+    @hub_error_handler
+    async def async_turn_on(self, **kwargs):
+        """Turn hot water on."""
+        await self._data.wiserhub.hotwater.override_state("On")
+        await self.async_force_update()
+
+    @hub_error_handler
+    async def async_turn_off(self, **kwargs):
+        """Turn hot water off."""
+        await self._data.wiserhub.hotwater.override_state("Off")
         await self.async_force_update()
 

--- a/tests/test_switch_hot_water.py
+++ b/tests/test_switch_hot_water.py
@@ -1,0 +1,142 @@
+"""Regression tests for the Hot Water switch without Home Assistant runtime deps."""
+
+from __future__ import annotations
+
+import asyncio
+import importlib.util
+from pathlib import Path
+import sys
+from types import ModuleType, SimpleNamespace
+import unittest
+
+
+SOURCE_PATH = Path(__file__).parents[1] / "custom_components/wiser/switch.py"
+
+
+def _module(name: str, **attributes: object) -> ModuleType:
+    """Create and register a lightweight module stub."""
+    module = ModuleType(name)
+    module.__dict__.update(attributes)
+    sys.modules[name] = module
+    return module
+
+
+def _load_switch_module() -> ModuleType:
+    """Load the switch module with only the imports needed by this test."""
+    _module("voluptuous", Schema=lambda *a, **k: None, Required=lambda *a, **k: None, Coerce=lambda *a, **k: None)
+
+    _module("homeassistant")
+    _module("homeassistant.components")
+
+    class SwitchEntity:
+        pass
+
+    _module("homeassistant.components.switch", SwitchEntity=SwitchEntity)
+    _module("homeassistant.const", ATTR_ENTITY_ID="entity_id")
+    _module("homeassistant.helpers")
+    _module("homeassistant.helpers.config_validation", entity_id=lambda x: x)
+    _module("homeassistant.core", HomeAssistant=object, callback=lambda func: func)
+
+    class CoordinatorEntity:
+        def __init__(self, *args: object) -> None:
+            pass
+
+    _module(
+        "homeassistant.helpers.update_coordinator", CoordinatorEntity=CoordinatorEntity
+    )
+
+    package = _module("wiser")
+    package.__path__ = []
+    _module(
+        "wiser.const",
+        DATA="data",
+        DOMAIN="wiser",
+        HOT_WATER="hot_water",
+        MANUFACTURER="Drayton",
+    )
+
+    def hub_error_handler(func):
+        return func
+
+    _module(
+        "wiser.helpers",
+        get_device_name=lambda _data, device_id, device_type="device": (
+            "Hot Water" if device_type == "Hot Water" else "Wiser HeatHub"
+        ),
+        get_room_name=lambda *_args: "Room",
+        get_identifier=lambda *_args: "identifier",
+        get_unique_id=lambda *_args: "unique-id",
+        hub_error_handler=hub_error_handler,
+    )
+
+    class WiserScheduleEntity:
+        pass
+
+    _module("custom_components")
+    _module("custom_components.wiser")
+    _module("custom_components.wiser.schedules", WiserScheduleEntity=WiserScheduleEntity)
+
+    spec = importlib.util.spec_from_file_location("wiser.switch", SOURCE_PATH)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+class WiserHotWaterSwitchTest(unittest.TestCase):
+    """Tests for the Hot Water on/off switch."""
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.switch_module = _load_switch_module()
+
+    def _switch(self, *, current_state: str):
+        hotwater = SimpleNamespace(
+            id=0,
+            current_state=current_state,
+            override_state=self._record_override_state,
+        )
+        self._override_calls = []
+        data = SimpleNamespace(
+            wiserhub=SimpleNamespace(
+                hotwater=hotwater, system=SimpleNamespace(name="WiserHeat045XXX")
+            )
+        )
+        switch = self.switch_module.WiserHotWaterSwitch(data, 0, "Hot Water")
+        switch.async_force_update = self._noop_async
+        return switch
+
+    async def _record_override_state(self, state: str) -> None:
+        self._override_calls.append(state)
+
+    async def _noop_async(self, *_args, **_kwargs) -> None:
+        return None
+
+    def test_is_on_when_hot_water_current_state_is_on(self) -> None:
+        switch = self._switch(current_state="On")
+
+        self.assertTrue(switch.is_on)
+
+    def test_is_off_when_hot_water_current_state_is_off(self) -> None:
+        switch = self._switch(current_state="Off")
+
+        self.assertFalse(switch.is_on)
+
+    def test_turn_on_overrides_hot_water_state_to_on(self) -> None:
+        switch = self._switch(current_state="Off")
+
+        asyncio.run(switch.async_turn_on())
+
+        self.assertEqual(self._override_calls, ["On"])
+
+    def test_turn_off_overrides_hot_water_state_to_off(self) -> None:
+        switch = self._switch(current_state="On")
+
+        asyncio.run(switch.async_turn_off())
+
+        self.assertEqual(self._override_calls, ["Off"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Adds `WiserHotWaterSwitch`, a stateful `SwitchEntity` that reflects the real `hotwater.current_state` and calls `override_state("On"/"Off")` on turn on/off, so Hot Water can be exposed to HomeKit as a proper switch with accurate state (instead of only the stateless "Toggle Hot Water" button that requires guessing at current state).
- Purely additive — the existing `WiserOverrideHotWaterButton` is left in place, so no existing entities/automations are broken.

Fixed issue #626

## Test plan
- [x] `python -m unittest discover -s tests -v` — all 17 tests pass (4 new tests added covering `is_on` state and turn on/off behaviour)
- [ ] Manual verification in local Home Assistant: new "Hot Water" switch entity appears alongside the existing button, and its state tracks actual hot water status

🤖 Generated with [Claude Code](https://claude.com/claude-code)