### PR TITLE
fix: handle multi-gang dimmer lights across all platforms (#681)

### DIFF
--- a/custom_components/wiser/__init__.py
+++ b/custom_components/wiser/__init__.py
@@ -8,9 +8,9 @@ import asyncio
 import logging
 
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import ConfigEntryNotReady
-from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC
 
 from .const import (
@@ -31,7 +31,12 @@ from .const import (
 )
 from .coordinator import WiserUpdateCoordinator
 from .frontend import JSModuleRegistration
-from .helpers import get_device_name, get_identifier, get_instance_count
+from .helpers import (
+    build_light_unique_id_migration,
+    get_device_name,
+    get_identifier,
+    get_instance_count,
+)
 from .services import async_setup_services
 from .websockets import async_register_websockets
 
@@ -103,6 +108,48 @@ async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) ->
     return True
 
 
+async def async_migrate_light_unique_ids(hass: HomeAssistant, config_entry, data) -> None:
+    """Preserve light entities across the multi-gang dimmer fix (#681/#683).
+
+    The fix keys every light-derived entity on the per-channel ``light_id``
+    instead of the physical device ``id`` (see build_light_unique_id_migration),
+    which changes the unique_ids of the light, its mode/LED/power-on selects,
+    its away-mode switch and its four capability binary_sensors. Without this
+    the pre-fix entities orphan on update, losing their history and dashboard
+    references. This renames the matching registry entries to the new scheme so
+    their entity_ids survive the update untouched.
+    """
+    mapping = build_light_unique_id_migration(data)
+    if not mapping:
+        return
+
+    ent_reg = er.async_get(hass)
+
+    @callback
+    def _migrate(entry: er.RegistryEntry) -> dict | None:
+        new_unique_id = mapping.get(entry.unique_id)
+        if not new_unique_id:
+            return None
+        # async_update_entity raises if the target unique_id already exists, so
+        # a partially-migrated setup can't be allowed to abort config entry
+        # setup: skip and keep the pre-fix entity as an orphan instead.
+        if ent_reg.async_get_entity_id(entry.domain, entry.platform, new_unique_id):
+            _LOGGER.warning(
+                "Wiser: not migrating unique_id %s -> %s, target already exists",
+                entry.unique_id,
+                new_unique_id,
+            )
+            return None
+        _LOGGER.info(
+            "Wiser: migrating light unique_id %s -> %s",
+            entry.unique_id,
+            new_unique_id,
+        )
+        return {"new_unique_id": new_unique_id}
+
+    await er.async_migrate_entries(hass, config_entry.entry_id, _migrate)
+
+
 async def async_setup_entry(hass: HomeAssistant, config_entry):
     """Set up Wiser from a config entry."""
     hass.data.setdefault(DOMAIN, {})
@@ -121,6 +168,11 @@ async def async_setup_entry(hass: HomeAssistant, config_entry):
         DATA: coordinator,
         UPDATE_LISTENER: update_listener,
     }
+
+    # Remap light entity unique_ids from the pre-#683 scheme before the
+    # platforms create entities, so existing light entities are preserved
+    # instead of orphaned (see async_migrate_light_unique_ids).
+    await async_migrate_light_unique_ids(hass, config_entry, coordinator)
 
     # Setup platforms
     await hass.config_entries.async_forward_entry_setups(config_entry, WISER_PLATFORMS)

--- a/custom_components/wiser/binary_sensor.py
+++ b/custom_components/wiser/binary_sensor.py
@@ -9,7 +9,7 @@ from homeassistant.components.binary_sensor import (
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import DATA, DOMAIN, MANUFACTURER
+from .const import DATA, DOMAIN, ENTITY_PREFIX, MANUFACTURER
 from .helpers import get_device_name, get_identifier, get_room_name, get_unique_id
 
 _LOGGER = logging.getLogger(__name__)
@@ -65,12 +65,22 @@ async def async_setup_entry(hass: HomeAssistant, config_entry, async_add_entitie
 
     # Light sensors
     for device in data.wiserhub.devices.lights.all:
+        # Key by the unique per-channel light_id, not device.id: multi-gang
+        # dimmers (2GANG/DIMMER/2) share one device id across their channels,
+        # so the second channel's sensors would collide on unique_id and be
+        # dropped.
         binary_sensors.extend(
             [
-                WiserStateIsDimmable(data, device.id, "Is Dimmable"),
-                WiserStateIsDimmable(data, device.id, "Is LED Indicator Supported"),
-                WiserStateIsDimmable(data, device.id, "Is Output Mode Supported"),
-                WiserStateIsDimmable(data, device.id, "Is Power On Behaviour Supported"),
+                WiserStateIsDimmable(data, device.light_id, "Is Dimmable"),
+                WiserStateIsDimmable(
+                    data, device.light_id, "Is LED Indicator Supported"
+                ),
+                WiserStateIsDimmable(
+                    data, device.light_id, "Is Output Mode Supported"
+                ),
+                WiserStateIsDimmable(
+                    data, device.light_id, "Is Power On Behaviour Supported"
+                ),
             ]
         )
 
@@ -349,6 +359,21 @@ class WiserStateIsDimmable(BaseBinarySensor):
     """Light IsDimmable sensor."""
 
     _attr_icon = "mdi:lightbulb-on-40"
+
+    def __init__(self, coordinator, light_id, sensor_type=""):
+        """Initialize the sensor."""
+        # Resolve by the unique per-channel light_id and take the (possibly
+        # shared) physical device id from the light, so multi-gang dimmer
+        # channels get distinct names/unique_ids while still grouping under one
+        # device. BaseBinarySensor keys name/unique_id on the shared device id.
+        self._light = coordinator.wiserhub.devices.lights.get_by_light_id(light_id)
+        self._light_id = light_id
+        super().__init__(coordinator, self._light.id, sensor_type)
+
+    @property
+    def name(self):
+        """Return the name of the sensor."""
+        return f"{ENTITY_PREFIX} {self._light.name} {self._sensor_type}"
 
 
 class WiserStateIsTiltSupported(BaseBinarySensor):

--- a/custom_components/wiser/helpers.py
+++ b/custom_components/wiser/helpers.py
@@ -1,3 +1,5 @@
+from collections import Counter
+
 from aioWiserHeatAPI.wiserhub import (
     WiserHubConnectionError,
     WiserHubAuthenticationError,
@@ -8,6 +10,16 @@ from .const import DOMAIN, ENTITY_PREFIX
 import logging
 
 _LOGGER = logging.getLogger(__name__)
+
+# Capability sensor types emitted per light by WiserStateIsDimmable
+# (binary_sensor.py), needed to rebuild the pre-fix name-based unique_ids in
+# build_light_unique_id_migration().
+LIGHT_BINARY_SENSOR_TYPES = (
+    "Is Dimmable",
+    "Is LED Indicator Supported",
+    "Is Output Mode Supported",
+    "Is Power On Behaviour Supported",
+)
 
 
 def hub_error_handler(func):
@@ -118,6 +130,65 @@ def get_identifier(data, device_id, device_type="device"):
 
 def get_unique_id(data, device_type, entity_type, device_id):
     return f"{data.wiserhub.system.name}-{device_type}-{entity_type}-{device_id}"
+
+
+def build_light_unique_id_migration(data) -> dict:
+    """Map pre-#683 light unique_ids to the new per-channel light_id scheme.
+
+    The multi-gang dimmer fix keys every light-derived entity on the unique
+    per-channel ``light_id`` (hub Lighting section) instead of the physical
+    device ``id`` (hub Devices section). Those id spaces differ even for
+    single-gang lights, so the unique_ids of the light, its mode/LED/power-on
+    selects, its away-mode switch and its four capability binary_sensors all
+    change on update. Returns ``{old_unique_id: new_unique_id}`` so the caller
+    can rename the existing registry entries and preserve them.
+
+    Multi-gang dimmer channels are skipped: before the fix their light and
+    select platforms crashed and their other entities collided on unique_id,
+    so their pre-fix registry state is ambiguous. They are left to orphan.
+    """
+    lights = data.wiserhub.devices.lights.all
+    if not lights:
+        return {}
+
+    # A physical device id shared by more than one light == multi-gang dimmer.
+    device_id_counts = Counter(light.id for light in lights)
+
+    mapping: dict[str, str] = {}
+    for light in lights:
+        if device_id_counts[light.id] > 1:
+            continue  # multi-gang: pre-fix state ambiguous, skip
+
+        old_id = light.id
+        new_id = light.light_id
+        ptype = light.product_type
+        old_name = get_device_name(data, old_id)
+        new_name = f"{ENTITY_PREFIX} {light.name}"
+
+        # light (name-based -> light_id-based)
+        mapping[get_unique_id(data, "device", "light", f"{old_name} Light")] = (
+            get_unique_id(data, "device", "light", new_id)
+        )
+
+        # light selects (id-based; entity_type stable, only the id changes)
+        for kind in ("mode-select", "led-indicator", "power_on_behaviour_select"):
+            mapping[get_unique_id(data, ptype, kind, old_id)] = get_unique_id(
+                data, ptype, kind, new_id
+            )
+
+        # away-mode switch (both name and id embedded in the unique_id)
+        mapping[
+            get_unique_id(data, ptype, f"{old_name} Away Mode Turns Off", old_id)
+        ] = get_unique_id(data, ptype, f"{new_name} Away Mode Turns Off", new_id)
+
+        # capability binary_sensors (name-based)
+        for stype in LIGHT_BINARY_SENSOR_TYPES:
+            mapping[
+                get_unique_id(data, "binary_sensor", stype, f"{old_name} {stype}")
+            ] = get_unique_id(data, "binary_sensor", stype, f"{new_name} {stype}")
+
+    # Drop no-ops where the two id spaces happen to coincide for a light.
+    return {old: new for old, new in mapping.items() if old != new}
 
 
 def get_room_name(data, room_id):

--- a/custom_components/wiser/light.py
+++ b/custom_components/wiser/light.py
@@ -11,7 +11,7 @@ from homeassistant.components.light import (
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import DATA, DOMAIN, MANUFACTURER_SCHNEIDER
+from .const import DATA, DOMAIN, ENTITY_PREFIX, MANUFACTURER_SCHNEIDER
 from .helpers import get_device_name, get_identifier, get_unique_id, hub_error_handler
 from .schedules import WiserScheduleEntity
 
@@ -28,10 +28,13 @@ async def async_setup_entry(hass: HomeAssistant, config_entry, async_add_entitie
     if data.wiserhub.devices.lights:
         _LOGGER.debug("Setting up light entities")
         for light in data.wiserhub.devices.lights.all:
+            # Key entities by the unique per-channel light_id, not light.id:
+            # multi-gang dimmers (2GANG/DIMMER/2) share one device id across
+            # their channels, and get_by_id() then returns a list, crashing setup.
             if light.is_dimmable:
-                wiser_lights.append(WiserDimmableLight(data, light.id))
+                wiser_lights.append(WiserDimmableLight(data, light.light_id))
             else:
-                wiser_lights.append(WiserLight(data, light.id))
+                wiser_lights.append(WiserLight(data, light.light_id))
         async_add_entities(wiser_lights, True)
 
 
@@ -42,8 +45,14 @@ class WiserLight(CoordinatorEntity, LightEntity, WiserScheduleEntity):
         """Initialize the sensor."""
         super().__init__(coordinator)
         self._data = coordinator
-        self._device_id = light_id
-        self._device = self._data.wiserhub.devices.lights.get_by_id(self._device_id)
+        # light_id is the unique per-channel id; resolve the light through it and
+        # derive the (possibly shared) physical device id from the light object,
+        # so device grouping still works for multi-gang dimmers.
+        self._light_id = light_id
+        self._device = self._data.wiserhub.devices.lights.get_by_light_id(
+            self._light_id
+        )
+        self._device_id = self._device.id
         self._schedule = self._device.schedule
         _LOGGER.debug(f"{self._data.wiserhub.system.name} {self.name} initialise")
 
@@ -56,7 +65,9 @@ class WiserLight(CoordinatorEntity, LightEntity, WiserScheduleEntity):
     @callback
     def _handle_coordinator_update(self) -> None:
         _LOGGER.debug(f"{self.name} updating")
-        self._device = self._data.wiserhub.devices.lights.get_by_id(self._device_id)
+        self._device = self._data.wiserhub.devices.lights.get_by_light_id(
+            self._light_id
+        )
         self._schedule = self._device.schedule
         self.async_write_ha_state()
 
@@ -78,7 +89,10 @@ class WiserLight(CoordinatorEntity, LightEntity, WiserScheduleEntity):
     @property
     def name(self):
         """Return the name of the Device."""
-        return f"{get_device_name(self._data, self._device.id)} Light"
+        # Use the per-channel light name directly. It already carries room and
+        # channel (e.g. "Badezimmer Badewanne") and is distinct per channel, so
+        # the two channels of a multi-gang dimmer no longer collide.
+        return f"{ENTITY_PREFIX} {self._device.name} Light"
 
     @property
     def icon(self):
@@ -90,7 +104,9 @@ class WiserLight(CoordinatorEntity, LightEntity, WiserScheduleEntity):
 
     @property
     def unique_id(self):
-        return get_unique_id(self._data, "device", "light", self.name)
+        # Base the unique_id on the unique light_id (not the name) so the
+        # channels of a multi-gang dimmer never collide.
+        return get_unique_id(self._data, "device", "light", self._light_id)
 
     @property
     def device_info(self):

--- a/custom_components/wiser/select.py
+++ b/custom_components/wiser/select.py
@@ -3,6 +3,7 @@ import asyncio
 from .const import (
     DATA,
     DOMAIN,
+    ENTITY_PREFIX,
     HOT_WATER,
     MANUFACTURER,
 )
@@ -35,16 +36,22 @@ async def async_setup_entry(hass: HomeAssistant, config_entry, async_add_entitie
     if data.wiserhub.devices.lights.count > 0:
         _LOGGER.debug("Setting up Light mode select")
         for light in data.wiserhub.devices.lights.all:
-            wiser_selects.extend([WiserLightModeSelect(data, light.id)])
+            # Key entities by the unique per-channel light_id, not light.id:
+            # multi-gang dimmers (2GANG/DIMMER/2) share one device id across
+            # their channels, so get_by_id() returns a list and .available_modes
+            # then raises, aborting setup of the whole select platform.
+            wiser_selects.extend([WiserLightModeSelect(data, light.light_id)])
             if light.is_led_indicator_supported:
-                wiser_selects.extend([WiserLightLedIndicatorSelect(data, light.id)])
+                wiser_selects.extend(
+                    [WiserLightLedIndicatorSelect(data, light.light_id)]
+                )
 
             if light.is_dimmable:
 #                if light.is_led_indicator_supported:
 #                    wiser_selects.extend([WiserLightLedIndicatorSelect(data, light.id)])
                 if light.is_power_on_behaviour_supported:
                     wiser_selects.extend(
-                        [WiserLightPowerOnBehaviourSelect(data, light.id)]
+                        [WiserLightPowerOnBehaviourSelect(data, light.light_id)]
                     )
 
     if data.wiserhub.devices.shutters.count > 0:
@@ -228,9 +235,13 @@ class WiserPowerTagCModeSelect(WiserSelectEntity, WiserScheduleEntity):
 class WiserLightModeSelect(WiserSelectEntity, WiserScheduleEntity):
     def __init__(self, data, light_id) -> None:
         """Initialize the sensor."""
-        self._device_id = light_id
+        # light_id is the unique per-channel id; resolve the light through it and
+        # derive the (possibly shared) physical device id from the light object,
+        # so device grouping still works for multi-gang dimmers.
+        self._light_id = light_id
+        self._device = data.wiserhub.devices.lights.get_by_light_id(light_id)
+        self._device_id = self._device.id
         super().__init__(data)
-        self._device = self._data.wiserhub.devices.lights.get_by_id(self._device_id)
         self._options = self._device.available_modes
         self._schedule = self._device.schedule
 
@@ -238,9 +249,25 @@ class WiserLightModeSelect(WiserSelectEntity, WiserScheduleEntity):
     def _handle_coordinator_update(self) -> None:
         """Fetch new state data for the sensor."""
         super()._handle_coordinator_update()
-        self._device = self._data.wiserhub.devices.lights.get_by_id(self._device_id)
+        self._device = self._data.wiserhub.devices.lights.get_by_light_id(
+            self._light_id
+        )
         self._schedule = self._device.schedule
         self.async_write_ha_state()
+
+    @property
+    def name(self):
+        """Return Name of device."""
+        # Per-channel light name so the two channels of a multi-gang dimmer do
+        # not collide (WiserSelectEntity.name would use the shared device id).
+        return f"{ENTITY_PREFIX} {self._device.name} Mode"
+
+    @property
+    def unique_id(self):
+        """Return unique ID of device"""
+        return get_unique_id(
+            self._data, self._device.product_type, "mode-select", self._light_id
+        )
 
 
 class WiserShutterModeSelect(WiserSelectEntity, WiserScheduleEntity):
@@ -264,16 +291,20 @@ class WiserShutterModeSelect(WiserSelectEntity, WiserScheduleEntity):
 class WiserLightPowerOnBehaviourSelect(WiserSelectEntity):
     def __init__(self, data, light_id) -> None:
         """Initialize the sensor."""
-        self._device_id = light_id
+        # See WiserLightModeSelect: resolve by the unique per-channel light_id.
+        self._light_id = light_id
+        self._device = data.wiserhub.devices.lights.get_by_light_id(light_id)
+        self._device_id = self._device.id
         super().__init__(data)
-        self._device = self._data.wiserhub.devices.lights.get_by_id(self._device_id)
         self._options = self._device.available_power_on_behaviour
 
     @callback
     def _handle_coordinator_update(self) -> None:
         """Fetch new state data for the sensor."""
         super()._handle_coordinator_update()
-        self._device = self._data.wiserhub.devices.lights.get_by_id(self._device_id)
+        self._device = self._data.wiserhub.devices.lights.get_by_light_id(
+            self._light_id
+        )
         self._options = self._device.available_power_on_behaviour
         self.async_write_ha_state()
 
@@ -284,13 +315,13 @@ class WiserLightPowerOnBehaviourSelect(WiserSelectEntity):
             self._data,
             self._device.product_type,
             "power_on_behaviour_select",
-            self._device_id,
+            self._light_id,
         )
 
     @property
     def name(self):
         """Return Name of device."""
-        return f"{get_device_name(self._data, self._device_id)} Power On Behaviour"
+        return f"{ENTITY_PREFIX} {self._device.name} Power On Behaviour"
 
     @property
     def current_option(self) -> str:
@@ -311,16 +342,20 @@ class WiserLightPowerOnBehaviourSelect(WiserSelectEntity):
 class WiserLightLedIndicatorSelect(WiserSelectEntity):
     def __init__(self, data, light_id) -> None:
         """Initialize the sensor."""
-        self._device_id = light_id
+        # See WiserLightModeSelect: resolve by the unique per-channel light_id.
+        self._light_id = light_id
+        self._device = data.wiserhub.devices.lights.get_by_light_id(light_id)
+        self._device_id = self._device.id
         super().__init__(data)
-        self._device = self._data.wiserhub.devices.lights.get_by_id(self._device_id)
         self._options = self._device.available_led_indicator
 
     @callback
     def _handle_coordinator_update(self) -> None:
         """Fetch new state data for the sensor."""
         super()._handle_coordinator_update()
-        self._device = self._data.wiserhub.devices.lights.get_by_id(self._device_id)
+        self._device = self._data.wiserhub.devices.lights.get_by_light_id(
+            self._light_id
+        )
         self._options = self._device.available_led_indicator
         self.async_write_ha_state()
 
@@ -331,13 +366,13 @@ class WiserLightLedIndicatorSelect(WiserSelectEntity):
             self._data,
             self._device.product_type,
             "led-indicator",
-            self._device_id,
+            self._light_id,
         )
 
     @property
     def name(self):
         """Return Name of device."""
-        return f"{get_device_name(self._data, self._device_id)} Led Indicator"
+        return f"{ENTITY_PREFIX} {self._device.name} Led Indicator"
 
     @property
     def current_option(self) -> str:

--- a/custom_components/wiser/sensor.py
+++ b/custom_components/wiser/sensor.py
@@ -58,10 +58,17 @@ async def async_setup_entry(hass: HomeAssistant, config_entry, async_add_entitie
     # Add hub wifi signal sensor
     wiser_sensors.append(WiserDeviceSignalSensor(data, 0, "Controller"))
     if data.wiserhub.devices:
+        # Multi-gang dimmers (2GANG/DIMMER/2) expose one _WiserLight per channel
+        # but share a single physical device id. Signal strength is a property of
+        # that physical device, so emit one signal sensor per device id — two
+        # channels would otherwise collide on unique_id and the second be dropped.
+        signal_sensor_device_ids = set()
         for device in data.wiserhub.devices.all:
-            wiser_sensors.append(
-                WiserDeviceSignalSensor(data, device.id, device.product_type)
-            )
+            if device.id not in signal_sensor_device_ids:
+                signal_sensor_device_ids.add(device.id)
+                wiser_sensors.append(
+                    WiserDeviceSignalSensor(data, device.id, device.product_type)
+                )
             if hasattr(device, "battery"):
                 wiser_sensors.append(
                     WiserBatterySensor(data, device.id, sensor_type="Battery")

--- a/custom_components/wiser/switch.py
+++ b/custom_components/wiser/switch.py
@@ -16,7 +16,7 @@ from homeassistant.helpers import config_validation as cv
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import DATA, DOMAIN, HOT_WATER, MANUFACTURER
+from .const import DATA, DOMAIN, ENTITY_PREFIX, HOT_WATER, MANUFACTURER
 from .helpers import (
     get_device_name,
     get_identifier,
@@ -134,11 +134,19 @@ async def async_setup_entry(hass: HomeAssistant, config_entry, async_add_entitie
             )
 
         elif switch["type"] == "device":
+            # Multi-gang dimmers (2GANG/DIMMER/2) expose one _WiserLight per
+            # channel but share a single physical device id. Device Lock and
+            # Identify act on that physical device, so emit one switch per device
+            # id — the second channel would otherwise collide on unique_id.
+            seen_device_ids = set()
             for device in [
                 device
                 for device in data.wiserhub.devices.all
                 if hasattr(device, switch["key"])
             ]:
+                if device.id in seen_device_ids:
+                    continue
+                seen_device_ids.add(device.id)
                 wiser_switches.append(
                     WiserDeviceSwitch(
                         data, switch["name"], switch["key"], switch["icon"], device.id
@@ -147,8 +155,11 @@ async def async_setup_entry(hass: HomeAssistant, config_entry, async_add_entitie
 
     # Add Lights (if any)
     for light in data.wiserhub.devices.lights.all:
+        # Key by the unique per-channel light_id, not light.id: multi-gang
+        # dimmers (2GANG/DIMMER/2) share one device id across their channels,
+        # so the second channel's switch would collide on unique_id.
         wiser_switches.extend(
-            [WiserLightAwayActionSwitch(data, light.id, f"Wiser {light.name}")]
+            [WiserLightAwayActionSwitch(data, light.light_id, f"Wiser {light.name}")]
         )
 
     # Add Shutters (if any)
@@ -625,24 +636,32 @@ class WiserLightAwayActionSwitch(WiserSwitch):
 
     def __init__(self, data, LightId, name) -> None:
         """Initialize the sensor."""
+        # LightId is the unique per-channel light_id; resolve the light through
+        # it and take the (possibly shared) physical device id for grouping, so
+        # the two channels of a multi-gang dimmer get distinct names/unique_ids.
         self._name = name
         self._light_id = LightId
+        self._light = data.wiserhub.devices.lights.get_by_light_id(LightId)
+        self._device_id = self._light.id
         super().__init__(data, name, "", "light", "mdi:lightbulb-off-outline")
-        self._light = self._data.wiserhub.devices.get_by_id(self._light_id)
         self._is_on = True if self._light.away_mode_action == "Off" else False
 
     @callback
     def _handle_coordinator_update(self) -> None:
         """Async Update to HA."""
         super()._handle_coordinator_update()
-        self._light = self._data.wiserhub.devices.get_by_id(self._light_id)
+        self._light = self._data.wiserhub.devices.lights.get_by_light_id(
+            self._light_id
+        )
         self._is_on = True if self._light.away_mode_action == "Off" else False
         self.async_write_ha_state()
 
     @property
     def name(self):
         """Return the name of the Device."""
-        return f"{get_device_name(self._data, self._light_id)} Away Mode Turns Off"
+        # Per-channel light name so the two channels of a multi-gang dimmer do
+        # not collide.
+        return f"{ENTITY_PREFIX} {self._light.name} Away Mode Turns Off"
 
     @property
     def unique_id(self):
@@ -655,8 +674,8 @@ class WiserLightAwayActionSwitch(WiserSwitch):
     def device_info(self):
         """Return device specific attributes."""
         return {
-            "name": get_device_name(self._data, self._light_id),
-            "identifiers": {(DOMAIN, get_identifier(self._data, self._light_id))},
+            "name": get_device_name(self._data, self._device_id),
+            "identifiers": {(DOMAIN, get_identifier(self._data, self._device_id))},
             "manufacturer": MANUFACTURER,
             "model": self._light.product_type,
             "sw_version": self._light.firmware_version,

--- a/tests/test_light_unique_id_migration.py
+++ b/tests/test_light_unique_id_migration.py
@@ -1,0 +1,162 @@
+"""Regression tests for the light unique_id migration (#681/#683).
+
+Verifies build_light_unique_id_migration() rebuilds the pre-fix unique_ids and
+maps them to the new per-channel light_id scheme, without any Home Assistant
+runtime dependency.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+import sys
+from types import ModuleType, SimpleNamespace
+import unittest
+
+
+SOURCE_PATH = Path(__file__).parents[1] / "custom_components/wiser/helpers.py"
+
+ENTITY_PREFIX = "Wiser"
+SYSTEM_NAME = "WiserHeatTEST"
+
+
+def _module(name: str, **attributes: object) -> ModuleType:
+    """Create and register a lightweight module stub."""
+    module = ModuleType(name)
+    module.__dict__.update(attributes)
+    sys.modules[name] = module
+    return module
+
+
+def _load_helpers_module() -> ModuleType:
+    """Load helpers.py with only the imports it needs stubbed out."""
+    _module(
+        "aioWiserHeatAPI",
+    )
+    _module(
+        "aioWiserHeatAPI.wiserhub",
+        WiserHubConnectionError=type("WiserHubConnectionError", (Exception,), {}),
+        WiserHubAuthenticationError=type(
+            "WiserHubAuthenticationError", (Exception,), {}
+        ),
+        WiserHubRESTError=type("WiserHubRESTError", (Exception,), {}),
+    )
+    _module("homeassistant")
+    _module("homeassistant.core", HomeAssistant=object)
+
+    package = _module("wiser")
+    package.__path__ = []
+    _module("wiser.const", DOMAIN="wiser", ENTITY_PREFIX=ENTITY_PREFIX)
+
+    spec = importlib.util.spec_from_file_location("wiser.helpers", SOURCE_PATH)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _light(*, device_id: int, light_id: int, product_type: str, name: str):
+    return SimpleNamespace(
+        id=device_id, light_id=light_id, product_type=product_type, name=name
+    )
+
+
+def _hub_data():
+    """A hub with two single-gang lights and one two-gang dimmer (shared id)."""
+    lights = [
+        _light(device_id=101, light_id=1, product_type="DimmableLight", name="Diele"),
+        _light(device_id=102, light_id=2, product_type="OnOffLight", name="Flur"),
+        # Two-gang dimmer: both channels share physical device id 200.
+        _light(device_id=200, light_id=3, product_type="DimmableLight", name="Bad Dusche"),
+        _light(device_id=200, light_id=4, product_type="DimmableLight", name="Bad Wanne"),
+    ]
+    # get_device_name resolves the physical device; only single-gang ids should
+    # ever be looked up (multi-gang is skipped before this is called). Raising on
+    # an unexpected id turns an accidental multi-gang resolution into a failure.
+    devices_by_id = {
+        101: SimpleNamespace(id=101, product_type="DimmableLight", name="Diele"),
+        102: SimpleNamespace(id=102, product_type="OnOffLight", name="Flur"),
+    }
+    rooms_by_device = {
+        101: SimpleNamespace(name="Diele"),
+        102: None,  # exercise the no-room name path
+    }
+
+    def get_by_id(device_id: int):
+        return devices_by_id[device_id]
+
+    def get_by_device_id(device_id: int):
+        return rooms_by_device[device_id]
+
+    return SimpleNamespace(
+        wiserhub=SimpleNamespace(
+            system=SimpleNamespace(name=SYSTEM_NAME),
+            rooms=SimpleNamespace(get_by_device_id=get_by_device_id),
+            devices=SimpleNamespace(
+                get_by_id=get_by_id,
+                lights=SimpleNamespace(all=lights),
+            ),
+        )
+    )
+
+
+class LightUniqueIdMigrationTest(unittest.TestCase):
+    """Tests for build_light_unique_id_migration()."""
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.helpers = _load_helpers_module()
+
+    def _mapping(self):
+        return self.helpers.build_light_unique_id_migration(_hub_data())
+
+    def test_light_entity_maps_name_to_light_id(self) -> None:
+        mapping = self._mapping()
+        old = f"{SYSTEM_NAME}-device-light-Wiser DimmableLight Diele Diele Light"
+        self.assertEqual(mapping[old], f"{SYSTEM_NAME}-device-light-1")
+
+    def test_selects_map_device_id_to_light_id(self) -> None:
+        mapping = self._mapping()
+        for kind in ("mode-select", "led-indicator", "power_on_behaviour_select"):
+            old = f"{SYSTEM_NAME}-DimmableLight-{kind}-101"
+            self.assertEqual(mapping[old], f"{SYSTEM_NAME}-DimmableLight-{kind}-1")
+
+    def test_away_switch_maps_name_and_id(self) -> None:
+        mapping = self._mapping()
+        old = (
+            f"{SYSTEM_NAME}-DimmableLight-"
+            "Wiser DimmableLight Diele Diele Away Mode Turns Off-101"
+        )
+        new = f"{SYSTEM_NAME}-DimmableLight-Wiser Diele Away Mode Turns Off-1"
+        self.assertEqual(mapping[old], new)
+
+    def test_capability_binary_sensors_map_name(self) -> None:
+        mapping = self._mapping()
+        old = f"{SYSTEM_NAME}-binary_sensor-Is Dimmable-Wiser DimmableLight Diele Diele Is Dimmable"
+        new = f"{SYSTEM_NAME}-binary_sensor-Is Dimmable-Wiser Diele Is Dimmable"
+        self.assertEqual(mapping[old], new)
+
+    def test_no_room_light_uses_type_and_name(self) -> None:
+        mapping = self._mapping()
+        old = f"{SYSTEM_NAME}-device-light-Wiser OnOffLight Flur Light"
+        self.assertEqual(mapping[old], f"{SYSTEM_NAME}-device-light-2")
+
+    def test_multi_gang_channels_are_skipped(self) -> None:
+        mapping = self._mapping()
+        # No mapping may reference the shared physical device id 200 ...
+        self.assertFalse(any("-200" in key for key in mapping))
+        # ... nor target the multi-gang channels' light_ids (3, 4).
+        self.assertNotIn(f"{SYSTEM_NAME}-device-light-3", mapping.values())
+        self.assertNotIn(f"{SYSTEM_NAME}-device-light-4", mapping.values())
+
+    def test_no_noop_entries_and_exact_count(self) -> None:
+        mapping = self._mapping()
+        # Every entry is a real rename.
+        self.assertTrue(all(old != new for old, new in mapping.items()))
+        # 2 single-gang lights x (1 light + 3 selects + 1 away + 4 binary) = 18.
+        self.assertEqual(len(mapping), 18)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_switch_hot_water.py
+++ b/tests/test_switch_hot_water.py
@@ -51,6 +51,7 @@ def _load_switch_module() -> ModuleType:
         "wiser.const",
         DATA="data",
         DOMAIN="wiser",
+        ENTITY_PREFIX="Wiser",
         HOT_WATER="hot_water",
         MANUFACTURER="Drayton",
     )


### PR DESCRIPTION
Fixes #681.

## Problem

With a multi-gang dimmer (`2GANG/DIMMER/2`) both channels share the same device
`id`. The `id` property in `aioWiserHeatAPI` only disambiguates
`2GANG/SWITCH/2` (`id * 1000 + endpoint`), not `2GANG/DIMMER/2`, so
`lights.get_by_id(id)` matches more than one light and returns a **list**:

```python
lights = [light for light in self.all if light.id == light_id]
if lights and len(lights) == 1:
    return lights[0]
return lights          # <-- list for a multi-gang dimmer
```

This breaks **every platform that builds entities from lights**:

- **`light.py`** — `WiserLight.__init__` stored the list in `self._device` and
  the next line (`self._device.schedule`) raised, aborting light setup (no
  lights at all).
- **`select.py`** — same list, `.available_modes` raised → the **whole select
  platform** failed to set up (Mode / Power On Behaviour / LED Indicator selects
  for *all* devices, not just lights, were lost).
- **`binary_sensor.py`, `switch.py`, `sensor.py`** — no crash, but the second
  channel's entities collided on `unique_id` and were dropped
  (`… does not generate unique IDs … already exists - ignoring`): the four light
  capability sensors, the "Away Mode Turns Off" / "Device Lock" / "Identify"
  switches, and the Signal sensor.

## Fix

Two shapes, depending on whether the entity belongs to the channel or the
physical device:

**Per-channel entities** (independently controllable): key by the unique
per-channel `light_id`, resolve via `lights.get_by_light_id()` (always returns a
single object), derive the shared physical `device_id` from the resolved light
for grouping, and base `name`/`unique_id` on the per-channel light.
- `light.py`: `WiserLight` / `WiserDimmableLight`
- `select.py`: `WiserLightModeSelect`, `WiserLightPowerOnBehaviourSelect`,
  `WiserLightLedIndicatorSelect`
- `binary_sensor.py`: `WiserStateIsDimmable` (given a light-aware `__init__` so
  the generic `BaseBinarySensor` stays untouched for rooms/shutters)
- `switch.py`: `WiserLightAwayActionSwitch`

**Device-level entities** (one physical device, one entity): emit once per
physical device `id` instead of once per channel.
- `switch.py`: "Device Lock" and "Identify" (`WiserDeviceSwitch` loop)
- `sensor.py`: the Signal sensor

## Entity migration

`_WiserLight.id` (hub Devices section) and `light_id` (hub Lighting section) are
different id spaces even for single-gang lights, so on upgrade the `unique_id`
of every per-channel light entity changes — the light, the mode/LED/power-on
selects, the away-mode switch and the four capability binary_sensors.
`241f547` adds `build_light_unique_id_migration()` (in `helpers.py`), run from
`async_setup_entry` **before** the platforms create entities, which rebuilds each
old `unique_id` from live hub data and renames the matching registry entry to
the new `light_id`-based one, so `entity_id`s, history and dashboards carry over.
The rename callback checks `async_get_entity_id` first, because
`async_update_entity` raises on a pre-existing target and would otherwise abort
config-entry setup.

Multi-gang dimmer channels created *before* the fix are deliberately left to
orphan: their light/select platforms had crashed (nothing to migrate) and their
binary_sensor/switch entities were keyed on the shared device `id` (one entity
for two channels), so there is no unambiguous target. Single-gang-only setups
migrate completely. The device-level dedupe (Device Lock, Identify, Signal)
keeps its `unique_id`s and does not migrate.

## Testing

Tested on a live hub with **five 2-gang dimmers (12 light channels)** plus
single-channel lights, on integration `3.4.20` with `aioWiserHeatAPI==1.7.3`.

- Before: light platform crashed (0 lights), select platform crashed, and the
  second channel of every dimmer lost its select / switch / binary-sensor
  entities.
- After: startup log is clean (no crash, no duplicate-unique-id warnings), the
  entity registry has a Mode select for **all 12** channels (both channels of
  every 2-gang dimmer), device-level switches/sensors appear once per device,
  and single-channel lights are unaffected.
- Migration cross-checked against the live registry: every new `unique_id`
  `build_light_unique_id_migration()` computes matches an existing entity.
- Added `tests/test_light_unique_id_migration.py` (single-gang mapping,
  multi-gang skip, no-op filter). `71cc6f7` also repairs `test_switch_hot_water.py`,
  whose `wiser.const` stub lacked the `ENTITY_PREFIX` this PR now imports in
  `switch.py`. Full `unittest` suite green.
