### PR TITLE
feat: optimistic light state for instant UI feedback

### DIFF
--- a/custom_components/wiser/light.py
+++ b/custom_components/wiser/light.py
@@ -45,6 +45,11 @@ class WiserLight(CoordinatorEntity, LightEntity, WiserScheduleEntity):
         self._device_id = light_id
         self._device = self._data.wiserhub.devices.lights.get_by_id(self._device_id)
         self._schedule = self._device.schedule
+        # Optimistic state: a just-sent command is reflected in the UI at once
+        # and held only until the follow-up refresh returns real hub data.
+        # None means "no command pending, use the device's own state".
+        self._optimistic_is_on = None
+        self._optimistic_percentage = None
         _LOGGER.debug(f"{self._data.wiserhub.system.name} {self.name} initialise")
 
     async def async_force_update(self, delay: int = 0):
@@ -73,6 +78,8 @@ class WiserLight(CoordinatorEntity, LightEntity, WiserScheduleEntity):
     @property
     def is_on(self):
         """Return the boolean response if the node is on."""
+        if self._optimistic_is_on is not None:
+            return self._optimistic_is_on
         return self._device.is_on
 
     @property
@@ -167,15 +174,21 @@ class WiserLight(CoordinatorEntity, LightEntity, WiserScheduleEntity):
     async def async_turn_on(self, **kwargs):
         """Turn light on."""
         if ATTR_BRIGHTNESS in kwargs:
-            brightness = int(kwargs[ATTR_BRIGHTNESS])
-            _LOGGER.debug(
-                f"Setting brightness of {self.name} to {round((brightness / 255) * 100)}%"
-            )
-            await self._device.set_current_percentage(round((brightness / 255) * 100))
+            percentage = round((int(kwargs[ATTR_BRIGHTNESS]) / 255) * 100)
+            _LOGGER.debug(f"Setting brightness of {self.name} to {percentage}%")
+            await self._device.set_current_percentage(percentage)
+            self._optimistic_percentage = percentage
         else:
             _LOGGER.debug(f"Turning on {self.name}")
             await self._device.turn_on()
-        await self.async_force_update(2)
+        # Reflect the command in the UI immediately (the hub only reports the new
+        # state a few seconds later); the refresh below then confirms it.
+        self._optimistic_is_on = True
+        self.async_write_ha_state()
+        try:
+            await self.async_force_update(2)
+        finally:
+            self._clear_optimistic_state()
         return True
 
     @hub_error_handler
@@ -183,8 +196,20 @@ class WiserLight(CoordinatorEntity, LightEntity, WiserScheduleEntity):
         """Turn light off."""
         _LOGGER.debug(f"Turning off {self.name}")
         await self._device.turn_off()
-        await self.async_force_update(2)
+        self._optimistic_is_on = False
+        self.async_write_ha_state()
+        try:
+            await self.async_force_update(2)
+        finally:
+            self._clear_optimistic_state()
         return True
+
+    @callback
+    def _clear_optimistic_state(self) -> None:
+        """Drop the optimistic override so the real hub state is shown again."""
+        self._optimistic_is_on = None
+        self._optimistic_percentage = None
+        self.async_write_ha_state()
 
 
 class WiserDimmableLight(WiserLight):
@@ -203,7 +228,12 @@ class WiserDimmableLight(WiserLight):
     @property
     def brightness(self):
         """Return the brightness of this light between 0..100."""
-        return round((self._device.current_percentage / 100) * 255)
+        percentage = (
+            self._optimistic_percentage
+            if self._optimistic_percentage is not None
+            else self._device.current_percentage
+        )
+        return round((percentage / 100) * 255)
 
     @property
     def extra_state_attributes(self):

--- a/custom_components/wiser/light.py
+++ b/custom_components/wiser/light.py
@@ -50,6 +50,10 @@ class WiserLight(CoordinatorEntity, LightEntity, WiserScheduleEntity):
         # None means "no command pending, use the device's own state".
         self._optimistic_is_on = None
         self._optimistic_percentage = None
+        # Bumped on every command. A command's delayed cleanup only clears the
+        # optimistic state if it is still the latest, so rapid toggles don't let
+        # an earlier command wipe a newer command's value.
+        self._optimistic_gen = 0
         _LOGGER.debug(f"{self._data.wiserhub.system.name} {self.name} initialise")
 
     async def async_force_update(self, delay: int = 0):
@@ -63,6 +67,15 @@ class WiserLight(CoordinatorEntity, LightEntity, WiserScheduleEntity):
         _LOGGER.debug(f"{self.name} updating")
         self._device = self._data.wiserhub.devices.lights.get_by_id(self._device_id)
         self._schedule = self._device.schedule
+        # Once the hub confirms the on/off command, drop the optimistic override
+        # so the real state takes over seamlessly. Clearing on a match never
+        # changes what is shown, so a slow hub can't revert the UI to the
+        # pre-command value between the command and its confirmation.
+        if (
+            self._optimistic_is_on is not None
+            and self._device.is_on == self._optimistic_is_on
+        ):
+            self._optimistic_is_on = None
         self.async_write_ha_state()
 
     @property
@@ -183,12 +196,17 @@ class WiserLight(CoordinatorEntity, LightEntity, WiserScheduleEntity):
             await self._device.turn_on()
         # Reflect the command in the UI immediately (the hub only reports the new
         # state a few seconds later); the refresh below then confirms it.
+        self._optimistic_gen += 1
+        gen = self._optimistic_gen
         self._optimistic_is_on = True
         self.async_write_ha_state()
         try:
             await self.async_force_update(2)
         finally:
-            self._clear_optimistic_state()
+            # Only the latest command clears the optimistic state; a superseded
+            # command must leave the newer command's value untouched.
+            if gen == self._optimistic_gen:
+                self._clear_optimistic_state()
         return True
 
     @hub_error_handler
@@ -196,12 +214,15 @@ class WiserLight(CoordinatorEntity, LightEntity, WiserScheduleEntity):
         """Turn light off."""
         _LOGGER.debug(f"Turning off {self.name}")
         await self._device.turn_off()
+        self._optimistic_gen += 1
+        gen = self._optimistic_gen
         self._optimistic_is_on = False
         self.async_write_ha_state()
         try:
             await self.async_force_update(2)
         finally:
-            self._clear_optimistic_state()
+            if gen == self._optimistic_gen:
+                self._clear_optimistic_state()
         return True
 
     @callback

--- a/tests/test_light_optimistic_state.py
+++ b/tests/test_light_optimistic_state.py
@@ -1,0 +1,170 @@
+"""Regression tests for the optimistic light state, without Home Assistant runtime deps.
+
+Covers the two guards that keep rapid/overlapping toggles from making the UI
+revert to a stale value:
+  * a generation counter, so a superseded command's delayed cleanup cannot wipe
+    a newer command's optimistic value;
+  * a confirm-on-coordinator-update clear, so the optimistic on/off override is
+    only dropped once the hub actually reports the commanded state.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import importlib.util
+from pathlib import Path
+import sys
+from types import ModuleType, SimpleNamespace
+import unittest
+
+
+SOURCE_PATH = Path(__file__).parents[1] / "custom_components/wiser/light.py"
+
+
+def _module(name: str, **attributes: object) -> ModuleType:
+    """Create and register a lightweight module stub."""
+    module = ModuleType(name)
+    module.__dict__.update(attributes)
+    sys.modules[name] = module
+    return module
+
+
+def _load_light_module() -> ModuleType:
+    """Load light.py with only the imports it needs stubbed out."""
+    _module("homeassistant")
+    _module("homeassistant.components")
+
+    class LightEntity:
+        pass
+
+    _module(
+        "homeassistant.components.light",
+        ATTR_BRIGHTNESS="brightness",
+        ColorMode=SimpleNamespace(ONOFF="onoff", BRIGHTNESS="brightness"),
+        LightEntity=LightEntity,
+    )
+    _module("homeassistant.core", HomeAssistant=object, callback=lambda func: func)
+
+    class CoordinatorEntity:
+        def __init__(self, *args: object) -> None:
+            pass
+
+    _module(
+        "homeassistant.helpers.update_coordinator", CoordinatorEntity=CoordinatorEntity
+    )
+
+    package = _module("wiser")
+    package.__path__ = []
+    _module("wiser.const", DATA="data", DOMAIN="wiser", MANUFACTURER_SCHNEIDER="Schneider")
+
+    def hub_error_handler(func):
+        return func  # identity: let exceptions surface in tests
+
+    _module(
+        "wiser.helpers",
+        get_device_name=lambda *_a, **_k: "Wiser Light",
+        get_identifier=lambda *_a, **_k: "identifier",
+        get_unique_id=lambda *_a, **_k: "unique-id",
+        hub_error_handler=hub_error_handler,
+    )
+
+    class WiserScheduleEntity:
+        pass
+
+    _module("wiser.schedules", WiserScheduleEntity=WiserScheduleEntity)
+
+    spec = importlib.util.spec_from_file_location("wiser.light", SOURCE_PATH)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+class _FakeDevice:
+    def __init__(self, *, is_on=False, current_percentage=0):
+        self.id = 1
+        self.is_on = is_on
+        self.current_percentage = current_percentage
+        self.schedule = None
+
+    async def turn_on(self):
+        self.is_on = True
+
+    async def turn_off(self):
+        self.is_on = False
+
+    async def set_current_percentage(self, percentage):
+        self.current_percentage = percentage
+        self.is_on = percentage > 0
+
+
+class LightOptimisticStateTest(unittest.TestCase):
+    """Tests for the optimistic on/off state and its two guards."""
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.light_module = _load_light_module()
+
+    def _light(self, *, is_on=False):
+        device = _FakeDevice(is_on=is_on)
+        data = SimpleNamespace(
+            wiserhub=SimpleNamespace(
+                system=SimpleNamespace(name="WiserTEST"),
+                devices=SimpleNamespace(
+                    lights=SimpleNamespace(get_by_id=lambda _id: device)
+                ),
+            ),
+            async_refresh=self._noop_async,
+        )
+        light = self.light_module.WiserLight(data, 1)
+        light.async_write_ha_state = lambda: None  # not an HA-managed entity here
+        return light, device
+
+    async def _noop_async(self, *_args, **_kwargs):
+        return None
+
+    def test_single_command_clears_optimistic(self):
+        light, device = self._light(is_on=False)
+        light.async_force_update = self._noop_async
+        asyncio.run(light.async_turn_on())
+        # The one and only command clears its own optimistic state on cleanup.
+        self.assertIsNone(light._optimistic_is_on)
+        self.assertTrue(light.is_on)  # falls through to the (now on) device
+
+    def test_superseded_command_does_not_clobber_newer(self):
+        light, device = self._light(is_on=False)
+
+        # Command A is turn_on. While A awaits its follow-up refresh, a newer
+        # command B (turn_off) lands: it bumps the generation and sets its own
+        # optimistic value. A's cleanup must then leave B's value alone.
+        async def force_update_with_intervening_command(delay=0):
+            light._optimistic_gen += 1
+            light._optimistic_is_on = False  # command B = turn off
+
+        light.async_force_update = force_update_with_intervening_command
+        asyncio.run(light.async_turn_on())  # command A
+
+        # Without the generation guard, A's finally would wipe this back to None
+        # and the UI would revert to the stale device state.
+        self.assertIs(light._optimistic_is_on, False)
+
+    def test_coordinator_update_clears_optimistic_once_confirmed(self):
+        light, device = self._light(is_on=False)
+        light._optimistic_is_on = True  # a turn_on is pending
+        light._optimistic_gen = 1
+
+        # Hub still reports off -> keep the optimistic override (no revert).
+        device.is_on = False
+        light._handle_coordinator_update()
+        self.assertIs(light._optimistic_is_on, True)
+
+        # Hub now confirms on -> drop the override; the shown value is unchanged.
+        device.is_on = True
+        light._handle_coordinator_update()
+        self.assertIsNone(light._optimistic_is_on)
+        self.assertTrue(light.is_on)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem

After turning a Wiser light on/off (or dimming it), Home Assistant only updates
the entity state **~2–3 seconds later**. `async_turn_on`/`async_turn_off` send
the command and then call `async_force_update(2)`, which deliberately waits 2 s
before re-polling the hub. The lamp reacts instantly, but the UI lags behind
that whole delay, which feels unresponsive.

## Change

Reflect the just-sent command in the entity state **immediately**, then confirm
it against real hub data:

- store an optimistic override (`_optimistic_is_on` / `_optimistic_percentage`)
  after the command is sent and `async_write_ha_state()` at once, so the UI
  updates without waiting for the poll;
- `is_on` / `brightness` return the override while it is set.

**Clearing the override robustly** (this is what keeps rapid toggles from
misbehaving — see the note below):

- a per-entity **generation counter**: each command bumps it, and a command's
  delayed `try/finally` cleanup only clears the override if it is still the
  latest command. So when commands overlap (fast toggling / dragging a dim
  slider), an earlier command's cleanup can no longer wipe the value a newer
  command just set;
- `_handle_coordinator_update` additionally drops the **on/off** override as
  soon as the hub reports the commanded state. Clearing on a match never changes
  what is shown, so a slow hub can't revert the UI to the pre-command value
  between the command and its confirmation. Brightness keeps the (now
  generation-guarded) timed cleanup, because the hub may legitimately report a
  remapped percentage that never equals the set value exactly.

Only `light.py` is touched. Behaviour is unchanged when no command is pending
(override is `None`), and physical changes (wall switch, app) still come through
the normal coordinator poll.

## Why the extra guards

The first version cleared the override **unconditionally** after each command's
2 s refresh. With overlapping commands, the *earlier* command's cleanup fired
mid-flight and wiped the *newer* command's optimistic value, so the UI briefly
snapped back to the stale hub state before settling ~2–3 s later. Reported
during testing on rapid on/off and rapid dim changes; the two guards above fix
it at the root.

## Testing

- `tests/test_light_optimistic_state.py`: a superseded command does not clobber
  a newer command's override (generation guard); the on/off override is dropped
  only once the hub confirms the state; a single command still clears normally.
  Full `unittest` suite green.
- Live hub: on/off and brightness show in the UI within a fraction of a second
  instead of ~2–3 s. Firing **overlapping** on/off and dim commands (fired
  concurrently inside the 2 s window) and sampling the state every 0.25 s, the
  entity now tracks the last command and holds it — no revert to the previous
  value across the 2 s marks — then settles on the real hub value seamlessly.

Independent of #683 (multi-gang fix): that PR changes `__init__`,
`_handle_coordinator_update`, `name` and `unique_id`; this one changes
`__init__`, `is_on`, `async_turn_on/off`, `brightness` and (now)
`_handle_coordinator_update`. The overlaps are clean insertions that merge
without conflict.
