### PR TITLE
Origin/issue677

### DIFF
--- a/custom_components/wiser/binary_sensor.py
+++ b/custom_components/wiser/binary_sensor.py
@@ -9,7 +9,7 @@ from homeassistant.components.binary_sensor import (
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import DATA, DOMAIN, MANUFACTURER, ENTITY_PREFIX
+from .const import DATA, DOMAIN, MANUFACTURER
 from .helpers import get_device_name, get_identifier, get_room_name, get_unique_id
 
 _LOGGER = logging.getLogger(__name__)
@@ -88,7 +88,6 @@ async def async_setup_entry(hass: HomeAssistant, config_entry, async_add_entitie
     for device in data.wiserhub.devices.binary_sensor.all:
         binary_sensors.extend(
             [
-                #BaseBinarySensor(data, device.id, "Active"),
                 WiserStateActive(data, device.id, "Active"),
             ]
         )
@@ -181,7 +180,7 @@ class SystemBinarySensor(CoordinatorEntity, BinarySensorEntity):
         self._sensor_type = sensor_type
         self._state = getattr(self._data.wiserhub.system, self._sensor_type.replace(" ", "_").lower())
         _LOGGER.debug(
-            f"{self._data.wiserhub.system.name} {self.name} initalise"  # noqa: E501
+            f"{self._data.wiserhub.system.name} {self._sensor_type} initalise"  # noqa: E501
         )
 
     @callback
@@ -200,8 +199,8 @@ class SystemBinarySensor(CoordinatorEntity, BinarySensorEntity):
     @property
     def name(self):
         """Return the name of the sensor."""
-        #return f" {DOMAIN} {self._sensor_type}"
-        return f" {ENTITY_PREFIX} {self._sensor_type}"
+        return f"{self._sensor_type}"
+        
     
     @property
     def unique_id(self):
@@ -254,7 +253,6 @@ class RoomBinarySensor(CoordinatorEntity, BinarySensorEntity):
     def name(self):
         """Return the name of the sensor."""
         return f"{get_room_name(self._data, self._room_id)} {self._sensor_type}"
-        #return f"{get_device_name(self._data, self._room_id, "room")}  {self._sensor_type}",  
     
     @property
     def unique_id(self):
@@ -328,7 +326,7 @@ class WiserEquipment(BaseBinarySensor):
 
 class WiserSummerDiscomfortPrevention(SystemBinarySensor):
     """Summer Discomfort Prevention sensor."""    
-    _attr_device_class = BinarySensorDeviceClass.HEAT
+    #_attr_device_class = BinarySensorDeviceClass.RUNNING
 
     @property
     def extra_state_attributes(self):
@@ -341,7 +339,7 @@ class WiserSummerDiscomfortPrevention(SystemBinarySensor):
 class WiserSummerComfortAvailable(SystemBinarySensor):
     """Summer Comfort Available sensor."""
     _attr_icon = "mdi:sofa"
-    _attr_device_class = BinarySensorDeviceClass.HEAT
+    #_attr_device_class = BinarySensorDeviceClass.HEAT
 
 class WiserPCMDeviceLimitReached(SystemBinarySensor):
     """Summer Comfort Available sensor."""

--- a/custom_components/wiser/binary_sensor.py
+++ b/custom_components/wiser/binary_sensor.py
@@ -9,7 +9,7 @@ from homeassistant.components.binary_sensor import (
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import DATA, DOMAIN, MANUFACTURER
+from .const import DATA, DOMAIN, MANUFACTURER, ENTITY_PREFIX
 from .helpers import get_device_name, get_identifier, get_room_name, get_unique_id
 
 _LOGGER = logging.getLogger(__name__)
@@ -200,7 +200,8 @@ class SystemBinarySensor(CoordinatorEntity, BinarySensorEntity):
     @property
     def name(self):
         """Return the name of the sensor."""
-        return f" {DOMAIN} {self._sensor_type}"
+        #return f" {DOMAIN} {self._sensor_type}"
+        return f" {ENTITY_PREFIX} {self._sensor_type}"
     
     @property
     def unique_id(self):

--- a/custom_components/wiser/binary_sensor.py
+++ b/custom_components/wiser/binary_sensor.py
@@ -86,7 +86,12 @@ async def async_setup_entry(hass: HomeAssistant, config_entry, async_add_entitie
 
     # Binary sensors active
     for device in data.wiserhub.devices.binary_sensor.all:
-        binary_sensors.extend([BaseBinarySensor(data, device.id, "Active")])
+        binary_sensors.extend(
+            [
+                #BaseBinarySensor(data, device.id, "Active"),
+                WiserStateActive(data, device.id, "Active"),
+            ]
+        )
 
     async_add_entities(binary_sensors, True)
 
@@ -106,7 +111,7 @@ class BaseBinarySensor(CoordinatorEntity, BinarySensorEntity):
         self._sensor_type = sensor_type
         self._device_data_key = device_data_key
 
-        _LOGGER.info(
+        _LOGGER.debug(
             f"{self._data.wiserhub.system.name} {self.name} initalise"  # noqa: E501
         )
 
@@ -195,11 +200,8 @@ class SystemBinarySensor(CoordinatorEntity, BinarySensorEntity):
     @property
     def name(self):
         """Return the name of the sensor."""
-#        return f"{get_device_name(self._data, self._data.wiserhub.system)} {self._sensor_type}"
-        HeatHub = self._data.wiserhub.system.name
-        HeatHub = HeatHub.replace("WiserHeat","HeatHub")
-        return f"{HeatHub} {self._sensor_type}"
-
+        return f" {DOMAIN} {self._sensor_type}"
+    
     @property
     def unique_id(self):
         """Return uniqueid."""
@@ -381,12 +383,20 @@ class WiserStateActive(BaseBinarySensor):
     def extra_state_attributes(self):
         """Return the state attributes of WindowDoor sensor."""
         attrs = {}   
-        if self._data.wiserhub.devices.binary_sensor.get_by_id(
+
+        match self._data.wiserhub.devices.binary_sensor.get_by_id(
                 self._device_id
-            ).type == "Door"  :   
-            attrs["device_class"] = BinarySensorDeviceClass.DOOR
-        else:  attrs["device_class"] = BinarySensorDeviceClass.WINDOW 
-        attrs["type"] = self._data.wiserhub.devices.binary_sensor.get_by_id(
-                self._device_id
-            ).type 
+            ).product_type:
+            case ('WindowDoorSensor'):     
+                if self._data.wiserhub.devices.binary_sensor.get_by_id(
+                        self._device_id
+                    ).type == "Door"  :   
+                    attrs["device_class"] = BinarySensorDeviceClass.DOOR
+                else:  
+                    attrs["device_class"] = BinarySensorDeviceClass.WINDOW
+
+                attrs["type"] = self._data.wiserhub.devices.binary_sensor.get_by_id(
+                        self._device_id
+                    ).type 
+                
         return attrs

--- a/custom_components/wiser/helpers.py
+++ b/custom_components/wiser/helpers.py
@@ -80,7 +80,8 @@ def get_device_name(data, device_id, device_type="device"):
             device_room = data.wiserhub.rooms.get_by_id(device.room_id)
             if device_room:
                 return f"{ENTITY_PREFIX} {device_room.name} {device.name}"
-            return f"{ENTITY_PREFIX} {device.name} {device.id}"
+            #return f"{ENTITY_PREFIX} {device.name} {device.id}"
+            return f"{ENTITY_PREFIX} {device.product_type} {device.name} "
 
         if device.product_type == "BoilerInterface":
             return f"{ENTITY_PREFIX} {device.product_type} {device.name}"

--- a/custom_components/wiser/helpers.py
+++ b/custom_components/wiser/helpers.py
@@ -79,9 +79,9 @@ def get_device_name(data, device_id, device_type="device"):
         if device.product_type in ["SmokeAlarmDevice", "ButtonPanel"]:
             device_room = data.wiserhub.rooms.get_by_id(device.room_id)
             if device_room:
-                return f"{ENTITY_PREFIX} {device_room.name} {device.name}"
-            #return f"{ENTITY_PREFIX} {device.name} {device.id}"
-            return f"{ENTITY_PREFIX} {device.product_type} {device.name} "
+                return f"{ENTITY_PREFIX} {device.product_type} {device_room.name} {device.name}"
+            return f"{ENTITY_PREFIX} {device.product_type} {device.name} {device.id}"
+            
 
         if device.product_type == "BoilerInterface":
             return f"{ENTITY_PREFIX} {device.product_type} {device.name}"

--- a/custom_components/wiser/sensor.py
+++ b/custom_components/wiser/sensor.py
@@ -162,6 +162,9 @@ async def async_setup_entry(hass: HomeAssistant, config_entry, async_add_entitie
                     WiserLTSPowerSensor(data, smartplug.id, sensor_type="Energy", name="Equipment Energy Delivered"),
                     WiserLTSPowerSensor(data, smartplug.id, sensor_type="Energy", name="Equipment Total Energy"),
                     WiserCurrentVoltageSensor(data, smartplug.id, sensor_type="Current"),
+                    # to ensure backward compatibility
+                    WiserSmartplugPower(data, smartplug.id, sensor_type="Power"),
+                    WiserSmartplugPower(data, smartplug.id, sensor_type="Total Power"),                    
                     
                 ]
                 )
@@ -269,6 +272,9 @@ async def async_setup_entry(hass: HomeAssistant, config_entry, async_add_entitie
                     WiserLTSPowerSensor(data, heating_actuator.id, sensor_type="Power", name="Equipment Power"),
                     WiserLTSPowerSensor(data, heating_actuator.id, sensor_type="Energy", name="Equipment Energy Delivered"),
                     WiserLTSPowerSensor(data, heating_actuator.id, sensor_type="Energy", name="Equipment Total Energy"),
+                    # to ensure backward compatibility
+                    WiserLTSPowerSensor(data, heating_actuator.id, sensor_type="Power"),
+                    WiserLTSPowerSensor(data, heating_actuator.id, sensor_type="Energy"),
                 ]
             )
             else:
@@ -475,6 +481,7 @@ class WiserDeviceSignalSensor(WiserSensor):
     @property
     def device_info(self):
         """Return device specific attributes."""
+               
         return {
             "name": get_device_name(self._data, self._device_id),
             "identifiers": {(DOMAIN, get_identifier(self._data, self._device_id))},

--- a/custom_components/wiser/sensor.py
+++ b/custom_components/wiser/sensor.py
@@ -363,7 +363,6 @@ class WiserSensor(CoordinatorEntity, SensorEntity):
             "via_device": (DOMAIN, self._data.wiserhub.system.name),
         }
 
-
 class WiserBatterySensor(WiserSensor):
     """Definition of a battery sensor for wiser iTRVs and RoomStats."""
 
@@ -435,7 +434,6 @@ class WiserBatterySensor(WiserSensor):
             "via_device": (DOMAIN, self._data.wiserhub.system.name),
         }
 
-
 class WiserDeviceSignalSensor(WiserSensor):
     """Definition of Wiser Device Sensor."""
 
@@ -480,8 +478,7 @@ class WiserDeviceSignalSensor(WiserSensor):
 
     @property
     def device_info(self):
-        """Return device specific attributes."""
-               
+        """Return device specific attributes."""               
         return {
             "name": get_device_name(self._data, self._device_id),
             "identifiers": {(DOMAIN, get_identifier(self._data, self._device_id))},
@@ -705,7 +702,6 @@ class WiserSystemHotWaterPreset(WiserSensor):
             "via_device": (DOMAIN, self._data.wiserhub.system.name),
         }
 
-
 class WiserSystemCircuitState(WiserSensor):
     """Definition of a Hotwater/Heating circuit state sensor."""
 
@@ -815,7 +811,6 @@ class WiserSystemCircuitState(WiserSensor):
             "model": HOT_WATER.title(),
             "via_device": (DOMAIN, self._data.wiserhub.system.name),
         }
-
 
 class WiserSystemCloudSensor(WiserSensor):
     """Sensor to display the status of the Wiser Cloud."""
@@ -927,7 +922,6 @@ class WiserCurrentVoltageSensor(WiserSensor):
             "sw_version": self._device.firmware_version,
             "via_device": (DOMAIN, self._data.wiserhub.system.name),
         }
-
 
 class WiserSmartplugPower(WiserSensor):
     """Sensor for the power of a Wiser SmartPlug."""
@@ -1640,7 +1634,6 @@ class WiserThresholdSensor(WiserSensor):
             "via_device": (DOMAIN, self._data.wiserhub.system.name),
         }
 
-
 class WiserThresholdLightLevelSensor(WiserThresholdSensor):
     """Sensor for light level of threshold devices."""
 
@@ -1762,6 +1755,7 @@ class WiserEquipmentSensor(WiserSensor):
             "sw_version": self._device.firmware_version,
             "via_device": (DOMAIN, self._data.wiserhub.system.name),
         }
+    
     @property
     def extra_state_attributes(self):
         """Return device state attributes."""


### PR DESCRIPTION
Fix for issue 677

Binary sensors name:
<img width="404" height="325" alt="image" src="https://github.com/user-attachments/assets/e6b3e3ca-d673-4354-9bc3-9c9e1c7d8945" />

The previous entities "power" and "total power" could be reintroduced:
<img width="400" height="530" alt="image" src="https://github.com/user-attachments/assets/28c1ba30-3ec3-47a8-96b3-9585830b204c" />
