### PR TITLE
fix: use gas burner icons for boiler output sensors

### DIFF
--- a/custom_components/wiser/sensor.py
+++ b/custom_components/wiser/sensor.py
@@ -1396,7 +1396,7 @@ class WiserOpenThermAttributeSensor(WiserSensor):
         if self._sensor_key == "estimated_boiler_output":
             return "mdi:gas-burner"
         if self._sensor_key == "maximum_capacity_kw":
-            return "mdi:flash"
+            return "mdi:gas-burner"
         if self._sensor_key == "coprocessor_version":
             return "mdi:chip"
         if self._sensor_key == "coprocessor_update_status":

--- a/custom_components/wiser/sensor.py
+++ b/custom_components/wiser/sensor.py
@@ -1393,7 +1393,9 @@ class WiserOpenThermAttributeSensor(WiserSensor):
             return "mdi:delta"
         if self._sensor_key == "boiler_exhaust_temperature":
             return "mdi:smoke"
-        if self._sensor_key in {"estimated_boiler_output", "maximum_capacity_kw"}:
+        if self._sensor_key == "estimated_boiler_output":
+            return "mdi:gas-burner"
+        if self._sensor_key == "maximum_capacity_kw":
             return "mdi:flash"
         if self._sensor_key == "coprocessor_version":
             return "mdi:chip"

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -680,7 +680,7 @@ class WiserOpenThermAttributeSensorTest(unittest.TestCase):
         self.assertEqual(sensor.native_unit_of_measurement, "kW")
         self.assertEqual(sensor.device_class, "power")
         self.assertEqual(sensor.state_class, "measurement")
-        self.assertEqual(sensor.icon, "mdi:flash")
+        self.assertEqual(sensor.icon, "mdi:gas-burner")
 
         self.opentherm.operational_data.json_data["SlaveStatus"] = 0
         sensor._handle_coordinator_update()

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -643,7 +643,7 @@ class WiserOpenThermAttributeSensorTest(unittest.TestCase):
     def test_additional_boiler_readings_have_native_metadata(self):
         readings = {
             "boiler_exhaust_temperature": (28, "°C", "temperature", "mdi:smoke"),
-            "maximum_capacity_kw": (30, "kW", "power", "mdi:flash"),
+            "maximum_capacity_kw": (30, "kW", "power", "mdi:gas-burner"),
             "minimum_modulation_level": (27, "%", None, "mdi:percent"),
         }
         for key, (value, unit, device_class, icon) in readings.items():


### PR DESCRIPTION
## Summary

Use `mdi:gas-burner` for these optional OpenTherm sensors:

- Estimated boiler output
- Maximum boiler capacity

The previous `mdi:flash` icon represented electrical power and was not appropriate for the boiler’s thermal burner output or rated capacity.

## Testing

Updated the existing sensor tests to verify that both boiler output sensors use `mdi:gas-burner`.