### PR TITLE
Fix deprecated parent device reference in hot-water switch

### DIFF
--- a/custom_components/wiser/switch.py
+++ b/custom_components/wiser/switch.py
@@ -1104,7 +1104,7 @@ class WiserHotWaterSwitch(WiserSwitch):
             },
             "manufacturer": MANUFACTURER,
             "model": HOT_WATER.title(),
-            "via_device": (DOMAIN, self._data.wiserhub.system.name),
+            **get_hub_via_device_info(self._data),
         }
 
     @hub_error_handler


### PR DESCRIPTION
The hot-water switch still used the deprecated via_device field, which can cause entity registration errors on newer Home Assistant versions.

Use the shared hub helper to supply via_device_id, matching the other Wiser entities.

Validation: all 136 tests pass; git diff --check passes.